### PR TITLE
Ignore Eclipse IDE specific files and directiories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ build/
 *.iml
 *.ipr
 *.iws
+
+#Eclipse specific
+bin/
+.settings/
+.classpath
+.project


### PR DESCRIPTION
Ignored eclipse files/directiories:
bin/ - output dir from eclipse gradle integration plugin
.settings/ - IDE modules specific configs dir
.classpath - project classpath settings file
.project - project type settings file
