### PR TITLE
Changed Long[] and Integer[] to correct types

### DIFF
--- a/src/main/java/com/vmware/vim25/HostCapability.java
+++ b/src/main/java/com/vmware/vim25/HostCapability.java
@@ -32,7 +32,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Created by Michael Rice on Sun May 24 16:15:35 CDT 2015
+ * Created by Michael Rice on Fri Jun 12 15:16:16 CDT 2015
+ * This code is auto generated using yavijava_generator
+ * https://github.com/yavijava/yavijava_generator
  *
  * Copyright 2015 Michael Rice
  *
@@ -104,7 +106,7 @@ public class HostCapability extends DynamicData {
     @Getter @Setter public Boolean vmDirectPathGen2Supported;
     @Getter @Setter public String[] vmDirectPathGen2UnsupportedReason;
     @Getter @Setter public String vmDirectPathGen2UnsupportedReasonExtended;
-    @Getter @Setter public Integer[] supportedVmfsMajorVersion;
+    @Getter @Setter public int[] supportedVmfsMajorVersion;
     @Getter @Setter public Boolean vStorageCapable;
     @Getter @Setter public Boolean snapshotRelayoutSupported;
     @Getter @Setter public Boolean firewallIpRulesSupported;

--- a/src/main/java/com/vmware/vim25/TaskFilterSpec.java
+++ b/src/main/java/com/vmware/vim25/TaskFilterSpec.java
@@ -32,7 +32,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Created by Michael Rice on Sun May 24 16:15:35 CDT 2015
+ * Created by Michael Rice on Fri Jun 12 15:16:16 CDT 2015
+ * This code is auto generated using yavijava_generator
+ * https://github.com/yavijava/yavijava_generator
  *
  * Copyright 2015 Michael Rice
  *
@@ -58,7 +60,7 @@ public class TaskFilterSpec extends DynamicData {
     @Getter @Setter public TaskInfoState[] state;
     @Getter @Setter public ManagedObjectReference alarm;
     @Getter @Setter public ManagedObjectReference scheduledTask;
-    @Getter @Setter public Integer[] eventChainId;
+    @Getter @Setter public int[] eventChainId;
     @Getter @Setter public String[] tag;
     @Getter @Setter public String[] parentTaskKey;
     @Getter @Setter public String[] rootTaskKey;

--- a/src/main/java/com/vmware/vim25/VirtualMachineConfigInfo.java
+++ b/src/main/java/com/vmware/vim25/VirtualMachineConfigInfo.java
@@ -30,11 +30,10 @@ POSSIBILITY OF SUCH DAMAGE.
 package com.vmware.vim25;
 import lombok.Getter;
 import lombok.Setter;
-
 import java.util.Calendar;
 
 /**
- * Created by Michael Rice on Thu Jun 11 17:52:06 CDT 2015
+ * Created by Michael Rice on Fri Jun 12 15:16:17 CDT 2015
  * This code is auto generated using yavijava_generator
  * https://github.com/yavijava/yavijava_generator
  *
@@ -62,8 +61,8 @@ public class VirtualMachineConfigInfo extends DynamicData {
     @Getter @Setter public String version;
     @Getter @Setter public String uuid;
     @Getter @Setter public String instanceUuid;
-    @Getter @Setter public Long[] npivNodeWorldWideName;
-    @Getter @Setter public Long[] npivPortWorldWideName;
+    @Getter @Setter public long[] npivNodeWorldWideName;
+    @Getter @Setter public long[] npivPortWorldWideName;
     @Getter @Setter public String npivWorldWideNameType;
     @Getter @Setter public short npivDesiredNodeWwns;
     @Getter @Setter public short npivDesiredPortWwns;

--- a/src/main/java/com/vmware/vim25/VirtualMachineConfigSpec.java
+++ b/src/main/java/com/vmware/vim25/VirtualMachineConfigSpec.java
@@ -32,7 +32,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * Created by Michael Rice on Thu Jun 11 17:52:06 CDT 2015
+ * Created by Michael Rice on Fri Jun 12 15:16:17 CDT 2015
  * This code is auto generated using yavijava_generator
  * https://github.com/yavijava/yavijava_generator
  *
@@ -52,14 +52,14 @@ import lombok.Setter;
  * @since 6.0
  */
 
-public class VirtualMachineConfigSpec extends DynamicData {
+public class    VirtualMachineConfigSpec extends DynamicData {
     @Getter @Setter public String changeVersion;
     @Getter @Setter public String name;
     @Getter @Setter public String version;
     @Getter @Setter public String uuid;
     @Getter @Setter public String instanceUuid;
-    @Getter @Setter public Long[] npivNodeWorldWideName;
-    @Getter @Setter public Long[] npivPortWorldWideName;
+    @Getter @Setter public long[] npivNodeWorldWideName;
+    @Getter @Setter public long[] npivPortWorldWideName;
     @Getter @Setter public String npivWorldWideNameType;
     @Getter @Setter public short npivDesiredNodeWwns;
     @Getter @Setter public short npivDesiredPortWwns;


### PR DESCRIPTION
When an optional property is found and is of type long or
int it needed to be Long or Integer. It is not the same for
an optional array of those types. When it is an array of int
or long it should be those basic types. This was fixed in
yavijava_generator/19

Fixes #93
