### PR TITLE
circumvents a bug which gives invalid HTTP w/ null header values

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -153,6 +153,10 @@ public class WSClient extends SoapClient {
 
         postCon.setDoOutput(true);
         postCon.setDoInput(true);
+        String soapAction = this.soapAction;
+        if (soapAction == null) {
+            soapAction = "";
+        }
         postCon.setRequestProperty(SoapAction.SOAP_ACTION_HEADER.toString(), soapAction);
         postCon.setRequestProperty("Content-Type", "text/xml; charset=utf-8");
 


### PR DESCRIPTION
`HttpURLConnection` handles `null` header values improperly, resulting in invalid HTTP:

```
SOAPAction\x0a\x0d
```

Which should be:

```
SOAPAction:\x0a\x0d
```

`soapAction` is `null` when initializing, so this bug cannot be prevented with yavijava's alternative HTTP clients.

vSphere doesn't care, but stricter HTTP servers do (I noticed the bug proxying through one such product).
