### PR TITLE
Ability to pass custom TrustManager to ServiceInstance

### DIFF
--- a/src/intTest/java/com/vmware/vim25/mo/ServiceInstanceIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/mo/ServiceInstanceIntTest.java
@@ -1,13 +1,18 @@
 package com.vmware.vim25.mo;
 
 import com.utility.LoadVcenterProps;
+import com.vmware.vim25.ws.TrustCustomSSLContextCreator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.X509TrustManager;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.rmi.RemoteException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 public class ServiceInstanceIntTest {
 
@@ -24,6 +29,9 @@ public class ServiceInstanceIntTest {
                 || "".equals(LoadVcenterProps.password.trim())) {
             throw new Exception("Vcenter credentials not loaded");
         }
+
+        // ensure that the ssl context is re-initialized for every test, so behavior for different trust managers can be verified
+        TrustCustomSSLContextCreator.setContextAlreadyCreated(false);
     }
 
     @Test
@@ -94,4 +102,127 @@ public class ServiceInstanceIntTest {
         }
     }
 
+    /**
+     * Tests case when a trust all manager is passed to the service instance. Verifies no exceptions are thrown and that the connection is accepted.
+     */
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordWithTrustAllManager() {
+        try {
+            ServiceInstance si = new ServiceInstance(new URL(LoadVcenterProps.url),
+                    LoadVcenterProps.userName, LoadVcenterProps.password, new TrustAllManager(), ServiceInstance.VIM25_NAMESPACE, 1000, 1000);
+             Assert.assertNotNull("Expected a non-null time from service instance", si.currentTime());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests case when no trust manager is provided and certs should not be ignored. Verifies an SSLHandshakeException occurs and the connection is not accepted.
+     */
+    @Test
+    public void testCreateServiceInstanceWithNullTrustManager() {
+        try {
+            new ServiceInstance(new URL(LoadVcenterProps.url),
+                    LoadVcenterProps.userName, LoadVcenterProps.password, null, ServiceInstance.VIM25_NAMESPACE, 1000, 1000);
+            Assert.fail("Expected an SSLHandshakeException to have been thrown when no trust manager is provided and certs are not ignored.");
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.assertTrue("Expected an SSLHandshakeException to have been thrown when no trust manager is provided and certs are not ignored.", e.getCause() instanceof SSLHandshakeException);
+        }
+    }
+
+    /**
+     * Tests case when a trust manager is provided but the server is not trusted. Verifies an SSLHandshakeException occurs and the connection is not accepted.
+     */
+    @Test
+    public void testCreateServiceInstanceWithProvidedTrustManagerServerNotTrusted() {
+        try {
+            X509TrustManager testUntrustedServerTrustManager = new UntrustedServerTrustManager();
+
+            new ServiceInstance(new URL(LoadVcenterProps.url),
+                    LoadVcenterProps.userName, LoadVcenterProps.password, testUntrustedServerTrustManager, ServiceInstance.VIM25_NAMESPACE, 1000, 1000);
+            Assert.fail("Expected an SSLHandshakeException to have been thrown when the trust manager provided simulates an untrusted server.");
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            e.printStackTrace();
+            Assert.assertTrue("Expected an SSLHandshakeException to have been thrown when the trust manager provided simulates an untrusted server.", e.getCause() instanceof SSLHandshakeException);
+        }
+    }
+
+    /**
+     * Tests case when a trust all manager is passed to the service instance. Then the same trust manager is passed to a new service instance for a session string.
+     * Verifies no exceptions are thrown and that the connection is accepted for both service instances.
+     */
+    @Test
+    public void testCreateServiceInstanceForSessionStringWithTrustAllManager() {
+        try {
+            TrustAllManager trustAllManager = new TrustAllManager();
+            ServiceInstance si = new ServiceInstance(new URL(LoadVcenterProps.url),
+                    LoadVcenterProps.userName, LoadVcenterProps.password, trustAllManager);
+            Assert.assertNotNull("Expected non-null service instance", si.currentTime());
+
+            ServiceInstance siFromSessionString = new ServiceInstance(new URL(LoadVcenterProps.url), si.getServerConnection().getSessionStr(), trustAllManager);
+            Assert.assertNotNull("Expected non-null service instance when creating with session string", siFromSessionString.currentTime());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests case when a trust all manager is passed to the service instance. Then a null trust manager is passed to a new service instance for a session string.
+     * Verifies an SSLHandshakeException is thrown for the session string service instance.
+     */
+    @Test
+    public void testCreateServiceInstanceForSessionStringWithNullTrustManager() {
+        try {
+            ServiceInstance si = new ServiceInstance(new URL(LoadVcenterProps.url),
+                    LoadVcenterProps.userName, LoadVcenterProps.password, new TrustAllManager(), ServiceInstance.VIM25_NAMESPACE, 1000, 1000);
+            Assert.assertNotNull("Expected non-null service instance", si.currentTime());
+
+            X509TrustManager nullTrustManager = null;
+            new ServiceInstance(new URL(LoadVcenterProps.url), si.getServerConnection().getSessionStr(), nullTrustManager);
+            Assert.fail("Expected an SSLHandshakeException to have been thrown when no trust manager is provided.");
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.assertTrue("Expected an SSLHandshakeException to have been thrown when no trust manager is provided.", e.getCause() instanceof SSLHandshakeException);
+        }
+    }
+
+    private static class TrustAllManager implements X509TrustManager {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+        }
+    }
+
+    private static class UntrustedServerTrustManager implements X509TrustManager {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) throws CertificateException {
+            throw new CertificateException("Intentional CertificateException to simulate an untrusted server.");
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+        }
+    }
 }

--- a/src/intTest/java/com/vmware/vim25/mo/ServiceInstanceIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/mo/ServiceInstanceIntTest.java
@@ -1,7 +1,7 @@
 package com.vmware.vim25.mo;
 
 import com.utility.LoadVcenterProps;
-import com.vmware.vim25.ws.TrustCustomSSLContextCreator;
+import com.vmware.vim25.ws.CustomSSLTrustContextCreator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +31,7 @@ public class ServiceInstanceIntTest {
         }
 
         // ensure that the ssl context is re-initialized for every test, so behavior for different trust managers can be verified
-        TrustCustomSSLContextCreator.setContextAlreadyCreated(false);
+        CustomSSLTrustContextCreator.setContextAlreadyCreated(false);
     }
 
     @Test
@@ -120,6 +120,8 @@ public class ServiceInstanceIntTest {
 
     /**
      * Tests case when no trust manager is provided and certs should not be ignored. Verifies an SSLHandshakeException occurs and the connection is not accepted.
+     * This must be run against a vCenter running on ssl and you should not have its cert in your keystore. This is because the default trust manager performs
+     * normal certificate verification against the JDK's default CA certs.
      */
     @Test
     public void testCreateServiceInstanceWithNullTrustManager() {

--- a/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
@@ -45,8 +45,6 @@ public class WSClientIntTest {
                     LoadVcenterProps.userName, LoadVcenterProps.password, true);
         } catch (MalformedURLException e) {
             e.printStackTrace();
-        } catch(RemoteException e) {
-
         }
 
         if(si != null) {

--- a/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
@@ -7,6 +7,7 @@ import java.util.Calendar;
 import javax.net.ssl.SSLHandshakeException;
 
 import com.vmware.vim25.*;
+import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,6 +19,9 @@ import com.vmware.vim25.mo.util.PropertyCollectorUtil;
 import javax.net.ssl.HttpsURLConnection;
 
 public class WSClientIntTest {
+
+    private static final Logger log = Logger.getLogger(WSClientIntTest.class);
+
     SoapClient wsClient = null;
 
 
@@ -41,14 +45,18 @@ public class WSClientIntTest {
                     LoadVcenterProps.userName, LoadVcenterProps.password, true);
         } catch (MalformedURLException e) {
             e.printStackTrace();
-        }
-        
-        wsClient = new WSClient(LoadVcenterProps.url, true);
+        } catch(RemoteException e) {
 
-        wsClient.setVimNameSpace(ServiceInstance.VIM25_NAMESPACE);
-        wsClient.setSoapActionOnApiVersion("5.5");
-        wsClient.setCookie(si.getSessionManager().getServerConnection()
-                .getVimService().getWsc().getCookie());
+        }
+
+        if(si != null) {
+            wsClient = new WSClient(LoadVcenterProps.url, true);
+
+            wsClient.setVimNameSpace(ServiceInstance.VIM25_NAMESPACE);
+            wsClient.setSoapActionOnApiVersion("5.5");
+            wsClient.setCookie(si.getSessionManager().getServerConnection()
+                    .getVimService().getWsc().getCookie());
+        }
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ManagedObjectReference.java
+++ b/src/main/java/com/vmware/vim25/ManagedObjectReference.java
@@ -29,6 +29,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 package com.vmware.vim25;
 
+import java.text.MessageFormat;
+
 /**
  * @author Steve Jin (http://www.doublecloud.org)
  * @version 5.1
@@ -61,5 +63,26 @@ public class ManagedObjectReference {
 
     public void set_value(String val) {
         this.val = val;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(this == obj)
+            return true;
+        if((obj == null) || (obj.getClass() != this.getClass()))
+            return false;
+
+        ManagedObjectReference mor = (ManagedObjectReference)obj;
+        return  mor.getType().equals(getType()) && mor.getVal().equals(getVal());
+    }
+
+    @Override
+    public int hashCode()  {
+        return val.hashCode() + type.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format("{0}:{1}", type, val);
     }
 }

--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -34,6 +34,7 @@ import com.vmware.vim25.mo.util.MorUtil;
 import com.vmware.vim25.ws.Client;
 import org.apache.log4j.Logger;
 
+import javax.net.ssl.TrustManager;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.rmi.RemoteException;
@@ -68,9 +69,19 @@ public class ServiceInstance extends ManagedObject {
         this(url, username, password, ignoreCert, VIM25_NAMESPACE);
     }
 
+    public ServiceInstance(URL url, String username, String password, TrustManager trustManager)
+            throws RemoteException, MalformedURLException {
+       this(url, username, password, trustManager, VIM25_NAMESPACE);
+    }
+
     public ServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace)
         throws RemoteException, MalformedURLException {
-        constructServiceInstance(url, username, password, ignoreCert, namespace, 0, 0);
+        constructServiceInstance(url, username, password, ignoreCert, namespace, 0, 0, null);
+    }
+
+    public ServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace)
+            throws RemoteException, MalformedURLException {
+        constructServiceInstance(url, username, password, false, namespace, 0, 0, trustManager);
     }
 
     public ServiceInstance(URL url, String username, String password, int connectTimeout, int readTimeout)
@@ -79,16 +90,26 @@ public class ServiceInstance extends ManagedObject {
     }
 
     public ServiceInstance(URL url, String username, String password, boolean ignoreCert, int connectTimeout, int readTimeout)
-        throws RemoteException, MalformedURLException {
+            throws RemoteException, MalformedURLException {
         this(url, username, password, ignoreCert, VIM25_NAMESPACE, connectTimeout, readTimeout);
+    }
+
+    public ServiceInstance(URL url, String username, String password, TrustManager trustManager, int connectTimeout, int readTimeout)
+            throws RemoteException, MalformedURLException {
+        this(url, username, password, trustManager, VIM25_NAMESPACE, connectTimeout, readTimeout);
     }
 
     public ServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
         throws RemoteException, MalformedURLException {
-        constructServiceInstance(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout);
+        constructServiceInstance(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout, null);
     }
 
-    protected void constructServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
+    public ServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout)
+            throws RemoteException, MalformedURLException {
+        constructServiceInstance(url, username, password, false, namespace, connectTimeout, readTimeout, trustManager);
+    }
+
+    protected void constructServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, TrustManager trustManager)
         throws RemoteException, MalformedURLException {
         if (url == null || username == null) {
             throw new NullPointerException("None of url, username can be null.");
@@ -101,6 +122,7 @@ public class ServiceInstance extends ManagedObject {
 
         vimService.getWsc().setConnectTimeout(connectTimeout);
         vimService.getWsc().setReadTimeout(readTimeout);
+        vimService.getWsc().setTrustManager(trustManager);
 
         serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
         vimService.getWsc().setSoapActionOnApiVersion(getApiVersion(serviceContent));
@@ -116,10 +138,20 @@ public class ServiceInstance extends ManagedObject {
         this(url, sessionStr, ignoreCert, VIM25_NAMESPACE);
     }
 
+    public ServiceInstance(URL url, String sessionStr, TrustManager trustManager)
+            throws RemoteException, MalformedURLException {
+        this(url, sessionStr, trustManager, VIM25_NAMESPACE);
+    }
+
     // sessionStr format: "vmware_soap_session=\"B3240D15-34DF-4BB8-B902-A844FDF42E85\""
     public ServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace)
         throws RemoteException, MalformedURLException {
-        constructServiceInstance(url, sessionStr, ignoreCert, namespace, 0, 0);
+        constructServiceInstance(url, sessionStr, ignoreCert, namespace, 0, 0, null);
+    }
+
+    public ServiceInstance(URL url, String sessionStr, TrustManager trustManager, String namespace)
+            throws RemoteException, MalformedURLException {
+        constructServiceInstance(url, sessionStr, false, namespace, 0, 0, trustManager);
     }
 
     public ServiceInstance(URL url, String sessionStr, boolean ignoreCert, int connectTimeout, int readTimeout)
@@ -127,13 +159,23 @@ public class ServiceInstance extends ManagedObject {
         this(url, sessionStr, ignoreCert, VIM25_NAMESPACE, connectTimeout, readTimeout);
     }
 
+    public ServiceInstance(URL url, String sessionStr, TrustManager trustManager, int connectTimeout, int readTimeout)
+            throws RemoteException, MalformedURLException {
+        this(url, sessionStr, trustManager, VIM25_NAMESPACE, connectTimeout, readTimeout);
+    }
+
     // sessionStr format: "vmware_soap_session=\"B3240D15-34DF-4BB8-B902-A844FDF42E85\""
     public ServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
         throws RemoteException, MalformedURLException {
-        constructServiceInstance(url, sessionStr, ignoreCert, namespace, connectTimeout, readTimeout);
+        constructServiceInstance(url, sessionStr, ignoreCert, namespace, connectTimeout, readTimeout, null);
     }
 
-    protected void constructServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
+    public ServiceInstance(URL url, String sessionStr, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout)
+            throws RemoteException, MalformedURLException {
+        constructServiceInstance(url, sessionStr, false, namespace, connectTimeout, readTimeout, trustManager);
+    }
+
+    protected void constructServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, TrustManager trustManager)
         throws RemoteException, MalformedURLException {
         if (url == null || sessionStr == null) {
             throw new NullPointerException("None of url, session string can be null.");
@@ -148,6 +190,7 @@ public class ServiceInstance extends ManagedObject {
 
         vimService.getWsc().setConnectTimeout(connectTimeout);
         vimService.getWsc().setReadTimeout(readTimeout);
+        vimService.getWsc().setTrustManager(trustManager);
 
         serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
         wsc.setSoapActionOnApiVersion(getApiVersion(serviceContent));
@@ -237,6 +280,10 @@ public class ServiceInstance extends ManagedObject {
 
     public int getReadTimeout() {
         return getServerConnection().getVimService().getWsc().getReadTimeout();
+    }
+
+    public TrustManager getTrustManager() {
+        return getServerConnection().getVimService().getWsc().getTrustManager();
     }
 
     protected String getApiVersion(ServiceContent serviceContent) {

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -4,6 +4,9 @@ import org.apache.http.Header;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -111,7 +114,7 @@ public class ApacheHttpClient extends SoapClient {
         }
         catch (Exception e1) {
             log.error("Exception caught while invoking method.", e1);
-            throw new RemoteException("VI SDK invoke exception:" + e1);
+            throw new RemoteException("VI SDK invoke exception:" + e1, e1);
         }
         finally {
             if (is != null) {
@@ -147,7 +150,7 @@ public class ApacheHttpClient extends SoapClient {
         }
     }
 
-    private InputStream post(String payload) {
+    private InputStream post(String payload) throws IOException {
         CloseableHttpClient httpclient;
         RequestConfig requestConfig = RequestConfig.custom()
             .setConnectTimeout(this.connectTimeout)
@@ -155,9 +158,10 @@ public class ApacheHttpClient extends SoapClient {
             .build();
         if (trustAllSSL) {
             httpclient = HttpClients.custom().setSSLSocketFactory(ApacheTrustSelfSigned.trust()).build();
-
-        }
-        else {
+        } else if(trustManager != null) {
+            LayeredConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(TrustCustomSSLContextCreator.getTrustContext(trustManager), new AllowAllHostnameVerifier());
+            httpclient = HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
+        } else {
             httpclient = HttpClients.createDefault();
         }
         HttpPost httpPost;
@@ -185,24 +189,19 @@ public class ApacheHttpClient extends SoapClient {
             httpPost.setHeader("Cookie", cookie);
         }
         httpPost.setEntity(stringEntity);
-        try {
-            CloseableHttpResponse response = httpclient.execute(httpPost);
-            InputStream inputStream = response.getEntity().getContent();
-            if (cookie == null) {
 
-                Header[] headers = response.getAllHeaders();
-                for (Header header : headers) {
-                    if (header.getName().equals("Set-Cookie")) {
-                        cookie = header.getValue();
-                        break;
-                    }
+        CloseableHttpResponse response = httpclient.execute(httpPost);
+        InputStream inputStream = response.getEntity().getContent();
+        if (cookie == null) {
+
+            Header[] headers = response.getAllHeaders();
+            for (Header header : headers) {
+                if (header.getName().equals("Set-Cookie")) {
+                    cookie = header.getValue();
+                    break;
                 }
             }
-            return inputStream;
         }
-        catch (IOException e) {
-            log.error("", e);
-        }
-        return null;
+        return inputStream;
     }
 }

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -153,6 +153,10 @@ public class ApacheHttpClient extends SoapClient {
             .setConnectTimeout(this.connectTimeout)
             .setSocketTimeout(this.readTimeout)
             .build();
+        if(trustAllSSL && trustManager != null) {
+            log.warn("The option to ignore certs has been set along with a provided trust manager. This is not a valid scenario and the trust manager will be ignored.");
+        }
+
         if (trustAllSSL) {
             httpclient = HttpClients.custom().setSSLSocketFactory(ApacheTrustSelfSigned.trust()).build();
         } else if(trustManager != null) {

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -12,9 +12,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.Logger;
 
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -159,7 +156,7 @@ public class ApacheHttpClient extends SoapClient {
         if (trustAllSSL) {
             httpclient = HttpClients.custom().setSSLSocketFactory(ApacheTrustSelfSigned.trust()).build();
         } else if(trustManager != null) {
-            LayeredConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(TrustCustomSSLContextCreator.getTrustContext(trustManager), new AllowAllHostnameVerifier());
+            LayeredConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(CustomSSLTrustContextCreator.getTrustContext(trustManager), new AllowAllHostnameVerifier());
             httpclient = HttpClients.custom().setSSLSocketFactory(sslConnectionSocketFactory).build();
         } else {
             httpclient = HttpClients.createDefault();

--- a/src/main/java/com/vmware/vim25/ws/Client.java
+++ b/src/main/java/com/vmware/vim25/ws/Client.java
@@ -1,5 +1,6 @@
 package com.vmware.vim25.ws;
 
+import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -147,6 +148,10 @@ public interface Client {
      * @param timeoutMilliSec Integer time in milliseconds
      */
     public void setReadTimeout(int timeoutMilliSec);
+
+    public TrustManager getTrustManager();
+
+    public void setTrustManager(TrustManager trustManager);
 
     /**
      * Sets the api version. The oldest supported will be v4.0

--- a/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
@@ -18,7 +18,7 @@ public class CustomSSLTrustContextCreator {
             }
 
             TrustManager[] trustManagers = new TrustManager[] { trustManager };
-            sslContext = SSLContext.getInstance("SSL");
+            sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, trustManagers, null);
         }catch(NoSuchAlgorithmException e) {
             throw new RemoteException("Unable to find suitable algorithm while attempting to communicate with remote server.", e);

--- a/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
@@ -6,7 +6,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class TrustCustomSSLContextCreator {
+public class CustomSSLTrustContextCreator {
 
     private static AtomicBoolean contextAlreadyCreated = new AtomicBoolean(false);
     private static SSLContext sslContext;

--- a/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/CustomSSLTrustContextCreator.java
@@ -11,7 +11,7 @@ public class CustomSSLTrustContextCreator {
     private static AtomicBoolean contextAlreadyCreated = new AtomicBoolean(false);
     private static SSLContext sslContext;
 
-    public static SSLContext getTrustContext(TrustManager trustManager) {
+    public static SSLContext getTrustContext(TrustManager trustManager) throws RemoteException {
         try {
             if (contextAlreadyCreated.getAndSet(true)) {
                 return sslContext;
@@ -24,9 +24,9 @@ public class CustomSSLTrustContextCreator {
             throw new RemoteException("Unable to find suitable algorithm while attempting to communicate with remote server.", e);
         } catch(KeyManagementException e) {
             throw new RemoteException("An error occurred initializing SSL context due to a problem with key management.", e);
-        } finally {
-            return sslContext;
         }
+
+        return sslContext;
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -2,6 +2,7 @@ package com.vmware.vim25.ws;
 
 import org.apache.log4j.Logger;
 
+import javax.net.ssl.TrustManager;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,6 +35,7 @@ public abstract class SoapClient implements Client {
     public String vimNameSpace = null;
     public int connectTimeout = 0;
     public int readTimeout = 0;
+    protected TrustManager trustManager;
 
     XmlGen xmlGen = new XmlGenDom();
 
@@ -167,6 +169,19 @@ public abstract class SoapClient implements Client {
      */
     public void setReadTimeout(int timeoutMilliSec) {
         this.readTimeout = timeoutMilliSec;
+    }
+
+    public TrustManager getTrustManager() {
+        return trustManager;
+    }
+
+    /**
+     * Set a custom trust manager responsible for material used when making trust decisions.
+     *
+     * @param trustManager
+     */
+    public void setTrustManager(TrustManager trustManager) {
+        this.trustManager = trustManager;
     }
 
     public StringBuffer readStream(InputStream is) throws IOException {

--- a/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
+++ b/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
@@ -27,7 +27,7 @@ public class TrustAllSSL {
     private static boolean alreadyCreated = false;
     private static SSLContext sslContext;
 
-    public static SSLContext getTrustContext() {
+    public static SSLContext getTrustContext() throws RemoteException {
         try {
             if (getAlreadyCreated()) {
                 return sslContext;
@@ -48,9 +48,9 @@ public class TrustAllSSL {
             throw new RemoteException("Unable to find suitable algorithm while attempting to communicate with remote server.", e);
         } catch (KeyManagementException e) {
             throw new RemoteException("Key Management exception while attempting to communicate with remote server.", e);
-        } finally {
-            return sslContext;
         }
+
+        return sslContext;
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ws/TrustCustomSSLContextCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/TrustCustomSSLContextCreator.java
@@ -1,0 +1,41 @@
+package com.vmware.vim25.ws;
+
+import javax.net.ssl.*;
+import java.rmi.RemoteException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TrustCustomSSLContextCreator {
+
+    private static AtomicBoolean contextAlreadyCreated = new AtomicBoolean(false);
+    private static SSLContext sslContext;
+
+    public static SSLContext getTrustContext(TrustManager trustManager) {
+        try {
+            if (contextAlreadyCreated.getAndSet(true)) {
+                return sslContext;
+            }
+
+            TrustManager[] trustManagers = new TrustManager[] { trustManager };
+            sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustManagers, null);
+        }catch(NoSuchAlgorithmException e) {
+            throw new RemoteException("Unable to find suitable algorithm while attempting to communicate with remote server.", e);
+        } catch(KeyManagementException e) {
+            throw new RemoteException("An error occurred initializing SSL context due to a problem with key management.", e);
+        } finally {
+            return sslContext;
+        }
+    }
+
+    /**
+     * Sets the contextAlreadyCreated boolean used to determine whether a new ssl context should be initialized or not.
+     * Exposed as public for unit testability.
+     *
+     * @param alreadyCreated
+     */
+    public static void setContextAlreadyCreated(boolean alreadyCreated) {
+        contextAlreadyCreated.set(alreadyCreated);
+    }
+}

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -40,8 +40,6 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.rmi.RemoteException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 
 /**
  * The Web Service Engine
@@ -119,19 +117,13 @@ public class WSClient extends SoapClient {
         HttpURLConnection postCon;
         if (baseUrl.getProtocol().equalsIgnoreCase("https") && ignoreCert) {
             postCon = (HttpsURLConnection) baseUrl.openConnection();
-            try {
-                ((HttpsURLConnection) postCon).setSSLSocketFactory(TrustAllSSL.getTrustContext().getSocketFactory());
+            ((HttpsURLConnection) postCon).setSSLSocketFactory(TrustAllSSL.getTrustContext().getSocketFactory());
+        } else if(baseUrl.getProtocol().equalsIgnoreCase("https") && !ignoreCert) {
+            postCon = (HttpsURLConnection) baseUrl.openConnection();
+            if(trustManager != null) {
+                ((HttpsURLConnection) postCon).setSSLSocketFactory(TrustCustomSSLContextCreator.getTrustContext(trustManager).getSocketFactory());
             }
-            catch (NoSuchAlgorithmException e) {
-                log.debug("Unable to find suitable algorithm while attempting to communicate with remote server.", e);
-                throw new RemoteException("Unable to find suitable algorithm while attempting to communicate with remote server.", e);
-            }
-            catch (KeyManagementException e) {
-                log.debug("Key Management exception while attempting to communicate with remote server.", e);
-                throw new RemoteException("Key Management exception while attempting to communicate with remote server.", e);
-            }
-        }
-        else {
+        } else {
             postCon = (HttpURLConnection) baseUrl.openConnection();
         }
 

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -121,7 +121,7 @@ public class WSClient extends SoapClient {
         } else if(baseUrl.getProtocol().equalsIgnoreCase("https") && !ignoreCert) {
             postCon = (HttpsURLConnection) baseUrl.openConnection();
             if(trustManager != null) {
-                ((HttpsURLConnection) postCon).setSSLSocketFactory(TrustCustomSSLContextCreator.getTrustContext(trustManager).getSocketFactory());
+                ((HttpsURLConnection) postCon).setSSLSocketFactory(CustomSSLTrustContextCreator.getTrustContext(trustManager).getSocketFactory());
             }
         } else {
             postCon = (HttpURLConnection) baseUrl.openConnection();

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -115,6 +115,11 @@ public class WSClient extends SoapClient {
 
     protected InputStream post(String soapMsg) throws IOException {
         HttpURLConnection postCon;
+
+        if(ignoreCert && trustManager != null) {
+            log.warn("The option to ignore certs has been set along with a provided trust manager. This is not a valid scenario and the trust manager will be ignored.");
+        }
+
         if (baseUrl.getProtocol().equalsIgnoreCase("https") && ignoreCert) {
             postCon = (HttpsURLConnection) baseUrl.openConnection();
             ((HttpsURLConnection) postCon).setSSLSocketFactory(TrustAllSSL.getTrustContext().getSocketFactory());

--- a/src/test/java/com/vmware/vim25/ManagedObjectReferenceTest.java
+++ b/src/test/java/com/vmware/vim25/ManagedObjectReferenceTest.java
@@ -1,0 +1,28 @@
+package com.vmware.vim25;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ManagedObjectReferenceTest {
+
+    @Test
+    public void testManagedObjectReferencesAreEqual() {
+        ManagedObjectReference mor1 = new ManagedObjectReference();
+        mor1.setType("HostSystem");
+        mor1.setVal("host-234");
+
+        ManagedObjectReference mor2 = new ManagedObjectReference();
+        mor2.setType("HostSystem");
+        mor2.setVal("host-234");
+        Assert.assertEquals(mor1, mor2);
+    }
+
+    @Test
+    public void testManagedObjectReferenceToString() {
+        ManagedObjectReference mor1 = new ManagedObjectReference();
+        mor1.setType("HostSystem");
+        mor1.setVal("host-234");
+        Assert.assertEquals("HostSystem:host-234", mor1.toString());
+    }
+
+}

--- a/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
@@ -170,8 +170,6 @@ public class ServiceInstanceTest {
         }
     }
 
-    // *******
-
     @Test
     public void testCreateServiceInstanceForSessionStringAndIgnoreCertsNoTimeouts() {
         try {

--- a/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
@@ -7,9 +7,12 @@ import com.vmware.vim25.VimPortType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.rmi.RemoteException;
+import java.security.cert.X509Certificate;
 
 public class ServiceInstanceTest {
 
@@ -20,6 +23,7 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(0, si.getConnectTimeout());
             Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -34,6 +38,7 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(2000, si.getConnectTimeout());
             Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -48,6 +53,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(0, si.getConnectTimeout());
             Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndTrustManagerNoTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", testTrustManager);
+
+            Assert.assertEquals(0, si.getConnectTimeout());
+            Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -62,6 +84,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(2000, si.getConnectTimeout());
             Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndTrustManagerWithTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", testTrustManager, 2000, 5000);
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -76,6 +115,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(0, si.getConnectTimeout());
             Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndTrustManagerAndNamespaceNoTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", testTrustManager, ServiceInstance.VIM25_NAMESPACE);
+
+            Assert.assertEquals(0, si.getConnectTimeout());
+            Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -90,6 +146,7 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(2000, si.getConnectTimeout());
             Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -98,12 +155,47 @@ public class ServiceInstanceTest {
     }
 
     @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndTrustManagerAndNamespaceWithTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", testTrustManager, ServiceInstance.VIM25_NAMESPACE, 2000, 5000);
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    // *******
+
+    @Test
     public void testCreateServiceInstanceForSessionStringAndIgnoreCertsNoTimeouts() {
         try {
             TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "\"vmware_soap_session=\\\"B3240D15-34DF-4BB8-B902-A844FDF42E85\\\"\"", true);
 
             Assert.assertEquals(0, si.getConnectTimeout());
             Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForSessionStringAndTrustManagerNoTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "\"vmware_soap_session=\\\"B3240D15-34DF-4BB8-B902-A844FDF42E85\\\"\"", testTrustManager);
+
+            Assert.assertEquals(0, si.getConnectTimeout());
+            Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -118,6 +210,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(2000, si.getConnectTimeout());
             Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForSessionStringAndTrustManagerWithTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "\"vmware_soap_session=\\\"B3240D15-34DF-4BB8-B902-A844FDF42E85\\\"\"", testTrustManager, 2000, 5000);
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -132,6 +241,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(0, si.getConnectTimeout());
             Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForSessionStringAndTrustManagerAndNamespaceNoTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "\"vmware_soap_session=\\\"B3240D15-34DF-4BB8-B902-A844FDF42E85\\\"\"", testTrustManager, ServiceInstance.VIM25_NAMESPACE);
+
+            Assert.assertEquals(0, si.getConnectTimeout());
+            Assert.assertEquals(0, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -146,6 +272,23 @@ public class ServiceInstanceTest {
 
             Assert.assertEquals(2000, si.getConnectTimeout());
             Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForSessionStringAndTrustManagerAndNamespaceWithTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "\"vmware_soap_session=\\\"B3240D15-34DF-4BB8-B902-A844FDF42E85\\\"\"", testTrustManager, ServiceInstance.VIM25_NAMESPACE, 2000, 5000);
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
         } catch(MalformedURLException e) {
             Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
         } catch(RemoteException e) {
@@ -165,6 +308,11 @@ public class ServiceInstanceTest {
             super(url, username, password, ignoreCert);
         }
 
+        private TestServiceInstance(URL url, String username, String password, TrustManager trustManager)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, trustManager);
+        }
+
         private TestServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace)
                 throws RemoteException, MalformedURLException {
             super(url, username, password, ignoreCert, namespace);
@@ -180,9 +328,24 @@ public class ServiceInstanceTest {
             super(url, username, password, ignoreCert, connectTimeout, readTimeout);
         }
 
+        private TestServiceInstance(URL url, String username, String password, TrustManager trustManager, int connectTimeout, int readTimeout)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, trustManager, connectTimeout, readTimeout);
+        }
+
         private TestServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
                 throws RemoteException, MalformedURLException {
             super(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout);
+        }
+
+        private TestServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, trustManager, namespace, connectTimeout, readTimeout);
+        }
+
+        private TestServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, trustManager, namespace);
         }
 
         private TestServiceInstance(URL url, String sessionStr, boolean ignoreCert)
@@ -190,9 +353,19 @@ public class ServiceInstanceTest {
             super(url, sessionStr, ignoreCert);
         }
 
+        private TestServiceInstance(URL url, String sessionStr, TrustManager trustManager)
+                throws RemoteException, MalformedURLException {
+            super(url, sessionStr, trustManager);
+        }
+
         private TestServiceInstance(URL url, String sessionStr, boolean ignoreCert, int connectTimeout, int readTimeout)
                 throws RemoteException, MalformedURLException {
             super(url, sessionStr, ignoreCert, connectTimeout, readTimeout);
+        }
+
+        private TestServiceInstance(URL url, String sessionStr, TrustManager trustManager, int connectTimeout, int readTimeout)
+                throws RemoteException, MalformedURLException {
+            super(url, sessionStr, trustManager, connectTimeout, readTimeout);
         }
 
         private TestServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace)
@@ -200,9 +373,19 @@ public class ServiceInstanceTest {
             super(url, sessionStr, ignoreCert, namespace);
         }
 
+        private TestServiceInstance(URL url, String sessionStr, TrustManager trustManager, String namespace)
+                throws RemoteException, MalformedURLException {
+            super(url, sessionStr, trustManager, namespace);
+        }
+
         private TestServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout)
                 throws RemoteException, MalformedURLException {
             super(url, sessionStr, ignoreCert, namespace, connectTimeout, readTimeout);
+        }
+
+        private TestServiceInstance(URL url, String sessionStr, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout)
+                throws RemoteException, MalformedURLException {
+            super(url, sessionStr, trustManager, namespace, connectTimeout, readTimeout);
         }
 
         @Override
@@ -223,6 +406,21 @@ public class ServiceInstanceTest {
         @Override
         protected String getApiVersion(ServiceContent serviceContent) {
             return "2.5";
+        }
+    }
+
+    private static class TestTrustManager implements X509TrustManager {
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return null;
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+        }
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] certs, String authType) {
         }
     }
 }


### PR DESCRIPTION
Added the ability to pass a custom trust manager. Our product requires we validate the server is trusted and allows the user to continue connecting, similar to what chrome does for an untrusted website. When a user accepts, we save the keystore in the cacerts file. This will allow a user of the API to pass a custom trust manager per connection without having to set it at the global default level.

Ive included this ability for WSClient and the ApacheHttpClient. In addition to this i fixed up some exception handling and provided a hashCode(), equals() and toString() method to ManagedObjectReference.
