### PR TITLE
Exception handling improvements

### DIFF
--- a/src/main/java/com/vmware/vim25/ManagedObjectNotFound.java
+++ b/src/main/java/com/vmware/vim25/ManagedObjectNotFound.java
@@ -45,4 +45,13 @@ public class ManagedObjectNotFound extends RuntimeFault {
     public void setObj(ManagedObjectReference obj) {
         this.obj = obj;
     }
+
+    @Override
+    public String getMessage() {
+        if (obj != null) {
+            return obj.getType() + ":" + obj.getVal();
+        } else {
+            return "<null ManagedObjectReference>";
+        }
+    }
 }

--- a/src/main/java/com/vmware/vim25/mo/util/MorUtil.java
+++ b/src/main/java/com/vmware/vim25/mo/util/MorUtil.java
@@ -36,6 +36,7 @@ import com.vmware.vim25.mo.ServerConnection;
 import org.apache.log4j.Logger;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Utility class for the Managed Object and ManagedObjectReference.
@@ -85,16 +86,23 @@ public class MorUtil {
         }
 
         String moType = mor.getType();
-
+        Class moClass = null;
         try {
-            Class<?> moClass = Class.forName(moPackageName + "." + moType);
+            moClass = Class.forName(moPackageName + "." + moType);
             Constructor constructor = moClass.getConstructor(
-                new Class[]{ServerConnection.class, ManagedObjectReference.class});
+                    new Class[]{ServerConnection.class, ManagedObjectReference.class});
             return (ManagedObject) constructor.newInstance(new Object[]{sc, mor});
         }
-        catch (Exception e) {
-            log.error("Failed to create MO for " + mor.toString(), e);
-            return null;
+        catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("vijava does not have an associated class for this mor: " + mor.getVal(), e);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException("No constructor found in vijava for class: " + moClass.getName(),e);
+        } catch (InstantiationException e){
+            throw new IllegalArgumentException("vijava is unable to create a managed object from this mor: " + mor.getVal(),e);
+        } catch (IllegalAccessException e){
+            throw new IllegalArgumentException("vijava is unable to create a managed object from this mor: " + mor.getVal(),e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalArgumentException("vijava is unable to create a managed object from this mor: " + mor.getVal(),e);
         }
     }
 

--- a/src/test/groovy/com/vmware/vim25/mo/TestExceptionNotCaught.groovy
+++ b/src/test/groovy/com/vmware/vim25/mo/TestExceptionNotCaught.groovy
@@ -1,0 +1,12 @@
+package com.vmware.vim25.mo
+
+import com.vmware.vim25.ManagedObjectReference
+
+/**
+ * Created by willkandrade on 7/30/15.
+ */
+class TestExceptionNotCaught {
+        public TestExceptionNotCaught(ServerConnection sc, ManagedObjectReference mor) {
+
+        }
+}

--- a/src/test/groovy/com/vmware/vim25/mo/TestInvocationTargetException.groovy
+++ b/src/test/groovy/com/vmware/vim25/mo/TestInvocationTargetException.groovy
@@ -1,0 +1,13 @@
+package com.vmware.vim25.mo
+
+import com.vmware.vim25.ManagedObjectReference
+
+/**
+ * Created by willkandrade on 7/29/15.
+ */
+class TestInvocationTargetException extends ManagedEntity{
+    public TestInvocationTargetException(ServerConnection sc, ManagedObjectReference mor) {
+        super (sc, mor)
+        throw new RuntimeException()
+    }
+}

--- a/src/test/groovy/com/vmware/vim25/mo/util/MorUtilTestSpec.groovy
+++ b/src/test/groovy/com/vmware/vim25/mo/util/MorUtilTestSpec.groovy
@@ -5,11 +5,6 @@ import com.vmware.vim25.mo.ManagedObject
 import com.vmware.vim25.mo.ServerConnection
 import com.vmware.vim25.mo.VirtualMachine
 import spock.lang.Specification
-
-import static groovy.test.GroovyAssert.shouldFail
-import static groovy.test.GroovyAssert.shouldFail
-import static groovy.test.GroovyAssert.shouldFail
-import static groovy.test.GroovyAssert.shouldFail
 import static groovy.test.GroovyAssert.shouldFail
 
 /**

--- a/src/test/groovy/com/vmware/vim25/ws/TestIOExceptionNullErrorStream.java
+++ b/src/test/groovy/com/vmware/vim25/ws/TestIOExceptionNullErrorStream.java
@@ -1,0 +1,31 @@
+package com.vmware.vim25.ws;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class TestIOExceptionNullErrorStream extends HttpURLConnection{
+    TestIOExceptionNullErrorStream() throws MalformedURLException{
+        super(new URL("http://www.foo.com"));
+    }
+    @Override
+    public void disconnect() {
+    }
+    @Override
+    public boolean usingProxy() {
+        return false;
+    }
+    @Override
+    public void connect() throws IOException {
+    }
+    @Override
+    public InputStream getInputStream() throws IOException{
+        throw new IOException();
+    }
+    @Override
+    public InputStream getErrorStream(){
+        return null;
+    }
+}

--- a/src/test/groovy/com/vmware/vim25/ws/TestIOExceptionWithErrorStream.java
+++ b/src/test/groovy/com/vmware/vim25/ws/TestIOExceptionWithErrorStream.java
@@ -1,0 +1,33 @@
+package com.vmware.vim25.ws;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+class TestIOExceptionWithErrorStream extends HttpURLConnection{
+    TestIOExceptionWithErrorStream() throws MalformedURLException{
+        super(new URL("http://www.foo.com"));
+    }
+    @Override
+    public void disconnect() {
+    }
+    @Override
+    public boolean usingProxy() {
+        return false;
+    }
+    @Override
+    public void connect() throws IOException {
+    }
+    @Override
+    public InputStream getInputStream() throws IOException{
+        throw new IOException();
+    }
+    @Override
+    public InputStream getErrorStream() {
+        String s = "There was an error retrieving the InputStream";
+        return new ByteArrayInputStream(s.getBytes());
+    }
+}

--- a/src/test/groovy/com/vmware/vim25/ws/WSClientSpec.groovy
+++ b/src/test/groovy/com/vmware/vim25/ws/WSClientSpec.groovy
@@ -4,6 +4,10 @@ import com.vmware.vim25.InvalidLogin
 import com.vmware.vim25.ManagedObjectReference
 import spock.lang.Specification
 
+import java.rmi.RemoteException
+
+import static groovy.test.GroovyAssert.shouldFail
+
 /**
  *  Copyright 2015 Michael Rice <michael@michaelrice.org>
  *
@@ -42,5 +46,20 @@ class WSClientSpec extends Specification {
 
         then:
         thrown(InvalidLogin)
+    }
+
+    def 'test IOException Handling during getInputStream'() {
+        setup:
+        TestIOExceptionNullErrorStream connect = new TestIOExceptionNullErrorStream();
+        TestIOExceptionWithErrorStream connect2 = new TestIOExceptionWithErrorStream();
+        WSClient wsClient = new WSClient("https://foo.com/sdk", true)
+
+        when:
+        String message = shouldFail RemoteException, {wsClient.getInputStreamFromConnection(connect)}
+        String message2 = new InputStreamReader(wsClient.getInputStreamFromConnection(connect2)).readLine();
+
+        then:
+        message.contains("An error occurred getting a response from the connection at url https://foo.com/sdk; nested exception is: ")
+        message2.contains("There was an error retrieving the InputStream")
     }
 }

--- a/src/test/java/com/vmware/vim25/ManagedObjectReferenceTest.java
+++ b/src/test/java/com/vmware/vim25/ManagedObjectReferenceTest.java
@@ -25,4 +25,15 @@ public class ManagedObjectReferenceTest {
         Assert.assertEquals("HostSystem:host-234", mor1.toString());
     }
 
+    @Test
+    public void testManagedObjectNotFoundToString(){
+        ManagedObjectReference mor1 = new ManagedObjectReference();
+        mor1.setType("HostSystem");
+        mor1.setVal("host-234");
+        ManagedObjectNotFound managedObjectNotFound = new ManagedObjectNotFound();
+        managedObjectNotFound.setObj(mor1);
+        Assert.assertEquals("com.vmware.vim25.ManagedObjectNotFound: HostSystem:host-234", managedObjectNotFound.toString());
+        managedObjectNotFound.setObj(null);
+        Assert.assertEquals("com.vmware.vim25.ManagedObjectNotFound: <null ManagedObjectReference>", managedObjectNotFound.toString());
+    }
 }

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.rmi.RemoteException;
 import java.util.Objects;
 
 public class XmlGenDomTest {
@@ -14,6 +15,20 @@ public class XmlGenDomTest {
     @Test(expected = InvalidLogin.class)
     public void testFromXML_Throws_Invalid_Login_When_Login_is_Invalid() throws Exception {
         InputStream inputStream = new FileInputStream(new File("src/test/java/com/vmware/vim25/ws/xml/InvalidLoginFault.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        xmlGenDom.fromXML("Login", inputStream);
+    }
+
+    @Test(expected = RemoteException.class)
+    public void parseSoapFault_Throws_RuntimeException() throws Exception {
+        InputStream inputStream = new FileInputStream(new File("src/test/java/com/vmware/vim25/ws/xml/CatchRuntimeExceptionTest.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        xmlGenDom.fromXML("Login", inputStream);
+    }
+
+    @Test(expected = RemoteException.class)
+    public void testFromXML_Throws_DocumentException() throws Exception {
+        InputStream inputStream = new FileInputStream(new File("src/test/java/com/vmware/vim25/ws/xml/CatchDocumentExceptionTest.xml"));
         XmlGenDom xmlGenDom = new XmlGenDom();
         xmlGenDom.fromXML("Login", inputStream);
     }

--- a/src/test/java/com/vmware/vim25/ws/xml/CatchDocumentExceptionTest.xml
+++ b/src/test/java/com/vmware/vim25/ws/xml/CatchDocumentExceptionTest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Body>
+<soapenv:Fault><faultcode>ServerFaultCode</faultcode><faultstring>Cannot complete login due to an incorrect user name or password.</faultstring><detail><InvalidLoginFault xmlns="urn:vim25" xsi:type="InvalidLogin"></InvalidLoginFault></detail></soapenv:Fault>
+</soapenv:Body>
+</soapenv:Envelope>

--- a/src/test/java/com/vmware/vim25/ws/xml/CatchRuntimeExceptionTest.xml
+++ b/src/test/java/com/vmware/vim25/ws/xml/CatchRuntimeExceptionTest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Body>
+<soapenv:Fault><faultcode>ServerFaultCode</faultcode><faultstring>Cannot complete login due to an incorrect user name or password.</faultstring><detail><InvalidLoginFault xmns="urn:vim25" xsi:type="2"></InvalidLoginFault></detail></soapenv:Fault>
+</soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Change to MorUtil.java :  
CreateExactManagedObject() would return null when an exception was thrown. The exception will now be wrapped and thrown up the stack instead of the caller expecting a non-null value and causing a NullPointerException.

Change to ManagedObjectNotFound.java: 
Increased the detail of the ManagedObjectNotFound message to gain more info when there is a null ManagedObjectReference.

Change to WsClient.java: 
When vCenter is unresponsive or slow to respond, the InputStream that is received may be null. Handled null InputStream so the original exception detail can be thrown up the stack instead of causing a NullPointerException somewhere else. This hid the actual problem from us which was due to connectivity issues.

Change to XmlGenDom.java:  
Update exception handling to include more detail when an error occurs while using the SaxReader to read the inputstream. Added extra detail during a runtime error while parsing a soap fault. This is to print out the soap fault since it can not be mapped.
