### PR TITLE
Javadoc cleanup for Java 8 from Andrew Lawrence

### DIFF
--- a/src/main/java/com/vmware/vim25/CannotComputeFTCompatibleHosts.java
+++ b/src/main/java/com/vmware/vim25/CannotComputeFTCompatibleHosts.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:54 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/CannotDisableDrsOnClusterManagedByVDC.java
+++ b/src/main/java/com/vmware/vim25/CannotDisableDrsOnClusterManagedByVDC.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:54 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/CannotEnableVmcpForCluster.java
+++ b/src/main/java/com/vmware/vim25/CannotEnableVmcpForCluster.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:54 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/DigestNotSupported.java
+++ b/src/main/java/com/vmware/vim25/DigestNotSupported.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:54 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/EVCConfigFault.java
+++ b/src/main/java/com/vmware/vim25/EVCConfigFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/FilterInUse.java
+++ b/src/main/java/com/vmware/vim25/FilterInUse.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:54 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayConnectFault.java
+++ b/src/main/java/com/vmware/vim25/GatewayConnectFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayHostNotReachable.java
+++ b/src/main/java/com/vmware/vim25/GatewayHostNotReachable.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayNotFound.java
+++ b/src/main/java/com/vmware/vim25/GatewayNotFound.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayNotReachable.java
+++ b/src/main/java/com/vmware/vim25/GatewayNotReachable.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayOperationRefused.java
+++ b/src/main/java/com/vmware/vim25/GatewayOperationRefused.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayToHostAuthFault.java
+++ b/src/main/java/com/vmware/vim25/GatewayToHostAuthFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayToHostConnectFault.java
+++ b/src/main/java/com/vmware/vim25/GatewayToHostConnectFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GatewayToHostTrustVerifyFault.java
+++ b/src/main/java/com/vmware/vim25/GatewayToHostTrustVerifyFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestMultipleMappings.java
+++ b/src/main/java/com/vmware/vim25/GuestMultipleMappings.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryFault.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryKeyAlreadyExists.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryKeyAlreadyExists.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryKeyFault.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryKeyFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryKeyHasSubkeys.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryKeyHasSubkeys.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryKeyInvalid.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryKeyInvalid.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryKeyParentVolatile.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryKeyParentVolatile.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryValueFault.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryValueFault.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/GuestRegistryValueNotFound.java
+++ b/src/main/java/com/vmware/vim25/GuestRegistryValueNotFound.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/HostHasComponentFailure.java
+++ b/src/main/java/com/vmware/vim25/HostHasComponentFailure.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/HostVsanInternalSystemDeleteVsanObjectsResult.java
+++ b/src/main/java/com/vmware/vim25/HostVsanInternalSystemDeleteVsanObjectsResult.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/HostVsanInternalSystemVsanPhysicalDiskDiagnosticsResult.java
+++ b/src/main/java/com/vmware/vim25/HostVsanInternalSystemVsanPhysicalDiskDiagnosticsResult.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/InaccessibleFTMetadataDatastore.java
+++ b/src/main/java/com/vmware/vim25/InaccessibleFTMetadataDatastore.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/IncompatibleHostForVmReplication.java
+++ b/src/main/java/com/vmware/vim25/IncompatibleHostForVmReplication.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/InsufficientGraphicsResourcesFault.java
+++ b/src/main/java/com/vmware/vim25/InsufficientGraphicsResourcesFault.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/InsufficientNetworkCapacity.java
+++ b/src/main/java/com/vmware/vim25/InsufficientNetworkCapacity.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/InsufficientNetworkResourcePoolCapacity.java
+++ b/src/main/java/com/vmware/vim25/InsufficientNetworkResourcePoolCapacity.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/InsufficientStorageIops.java
+++ b/src/main/java/com/vmware/vim25/InsufficientStorageIops.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/MemoryFileFormatNotSupportedByDatastore.java
+++ b/src/main/java/com/vmware/vim25/MemoryFileFormatNotSupportedByDatastore.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/MultiWriterNotSupported.java
+++ b/src/main/java/com/vmware/vim25/MultiWriterNotSupported.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/NotSupportedHostForChecksum.java
+++ b/src/main/java/com/vmware/vim25/NotSupportedHostForChecksum.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/NotSupportedHostForVmcp.java
+++ b/src/main/java/com/vmware/vim25/NotSupportedHostForVmcp.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/NotSupportedHostForVmemFile.java
+++ b/src/main/java/com/vmware/vim25/NotSupportedHostForVmemFile.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/ReplicationVmInProgressFault.java
+++ b/src/main/java/com/vmware/vim25/ReplicationVmInProgressFault.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/RestrictedByAdministrator.java
+++ b/src/main/java/com/vmware/vim25/RestrictedByAdministrator.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/StorageDrsHbrDiskNotMovable.java
+++ b/src/main/java/com/vmware/vim25/StorageDrsHbrDiskNotMovable.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/StorageDrsHmsMoveInProgress.java
+++ b/src/main/java/com/vmware/vim25/StorageDrsHmsMoveInProgress.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/StorageDrsHmsUnreachable.java
+++ b/src/main/java/com/vmware/vim25/StorageDrsHmsUnreachable.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/StorageDrsRelocateDisabled.java
+++ b/src/main/java/com/vmware/vim25/StorageDrsRelocateDisabled.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/StorageDrsStaleHmsCollection.java
+++ b/src/main/java/com/vmware/vim25/StorageDrsStaleHmsCollection.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VFlashCacheHotConfigNotSupported.java
+++ b/src/main/java/com/vmware/vim25/VFlashCacheHotConfigNotSupported.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VmFaultToleranceTooManyFtVcpusOnHost.java
+++ b/src/main/java/com/vmware/vim25/VmFaultToleranceTooManyFtVcpusOnHost.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VmSmpFaultToleranceTooManyVMsOnHost.java
+++ b/src/main/java/com/vmware/vim25/VmSmpFaultToleranceTooManyVMsOnHost.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VsanIncompatibleDiskMapping.java
+++ b/src/main/java/com/vmware/vim25/VsanIncompatibleDiskMapping.java
@@ -2,15 +2,15 @@ package com.vmware.vim25;
 
 /**
  * Created by Michael Rice on Thu May 21 01:07:55 CDT 2015
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VsanNewPolicyBatch.java
+++ b/src/main/java/com/vmware/vim25/VsanNewPolicyBatch.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VsanPolicyChangeBatch.java
+++ b/src/main/java/com/vmware/vim25/VsanPolicyChangeBatch.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/VsanPolicySatisfiability.java
+++ b/src/main/java/com/vmware/vim25/VsanPolicySatisfiability.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/AlarmManager.java
+++ b/src/main/java/com/vmware/vim25/mo/AlarmManager.java
@@ -44,15 +44,32 @@ public class AlarmManager extends ManagedObject {
         super(sc, mor);
     }
 
+    /**
+     * Gets the values used by default for the client alarm wizard.
+     *
+     * @return The default setting for each {@link AlarmExpression}
+     */
     public AlarmExpression[] getDefaultExpression() {
         return (AlarmExpression[]) getCurrentProperty("defaultExpression");
     }
 
+    /**
+     * @return The set of descriptions used in alarms.
+     */
     public AlarmDescription getDescription() {
         return (AlarmDescription) this.getCurrentProperty("description");
     }
 
     /**
+     * Acknowledge the alarm for a managed entity.
+     *
+     * @param alarm
+     *            The {@link Alarm} to acknowledge.
+     * @param entity
+     *            The {@link ManagedEntity} which the alarm applies to.
+     * @throws RuntimeFault
+     *             if any unhandled runtime fault occurs
+     * @throws RemoteException
      * @since 4.0
      */
     public void acknowledgeAlarm(Alarm alarm, ManagedEntity entity) throws RuntimeFault, RemoteException {
@@ -60,14 +77,34 @@ public class AlarmManager extends ManagedObject {
     }
 
     /**
-     * @since 4.x
-     * added to yavija for 5.5b.07
+     * Set the status of an alarm for the given managed entity. Not a public
+     * VMware API.
+     *
+     * @param alarm
+     *            The {@link Alarm} to set the status of.
+     * @param entity
+     *            The {@link ManagedEntity} the alarm applies to.
+     * @param status
+     *            The string status corresponding to a
+     *            {@link ManagedEntityStatus} to set.
+     * @throws RuntimeFault
+     *             if any unhandled runtime fault occurs
+     * @throws RemoteException
+     * @since 4.x added to yavija for 5.5b.07
      */
     public void setAlarmStatus(Alarm alarm, ManagedEntity entity, String status) throws RuntimeFault, RemoteException {
         getVimService().setAlarmStatus(getMOR(), alarm.getMOR(), entity.getMOR(), status);
     }
 
     /**
+     * Whether or not alarm actions are available on the given ManagedEntity
+     *
+     * @param entity
+     *            The {@link ManagedEntity} to query.
+     * @return true if alarm actions are available
+     * @throws RuntimeFault
+     *             if any unhandled runtime fault occurs
+     * @throws RemoteException
      * @since 4.0
      */
     public boolean areAlarmActionsEnabled(ManagedEntity entity) throws RuntimeFault, RemoteException {
@@ -75,12 +112,38 @@ public class AlarmManager extends ManagedObject {
     }
 
     /**
+     * Toggles alarms on the given managed entity.
+     *
+     * @param entity
+     *            The {@link ManagedEntity} to toggle alarms on.
+     * @param enabled
+     *            Whether to enable or disable alarms.
+     * @throws RuntimeFault
+     *             if any unhandled runtime fault occurs
+     * @throws RemoteException
      * @since 4.0
      */
     public void enableAlarmActions(ManagedEntity entity, boolean enabled) throws RuntimeFault, RemoteException {
         getVimService().enableAlarmActions(getMOR(), entity.getMOR(), enabled);
     }
 
+    /**
+     * Create an alarm against the given managed entity using the alarm
+     * specification
+     *
+     * @param me
+     *            The {@link ManagedEntity} to alarm against.
+     * @param as
+     *            The {@link AlarmSpec} used to generate the alarm.
+     * @return The new {@link ALarm} created
+     * @throws InvalidName
+     *             if the alarm name exceeds the max length or is empty.
+     * @throws DuplicateName
+     *             if an alarm with the same name already exists.
+     * @throws RuntimeFault
+     *             if any unhandled runtime fault occurs
+     * @throws RemoteException
+     */
     public Alarm createAlarm(ManagedEntity me, AlarmSpec as) throws InvalidName, DuplicateName, RuntimeFault, RemoteException {
         if (me == null) {
             throw new IllegalArgumentException("entity must not be null.");
@@ -89,6 +152,12 @@ public class AlarmManager extends ManagedObject {
         return new Alarm(getServerConnection(), mor);
     }
 
+    /**
+     * @param me
+     * @return
+     * @throws RuntimeFault
+     * @throws RemoteException
+     */
     public Alarm[] getAlarm(ManagedEntity me) throws RuntimeFault, RemoteException {
         ManagedObjectReference[] mors = getVimService().getAlarm(getMOR(), me == null ? null : me.getMOR());
 
@@ -103,6 +172,12 @@ public class AlarmManager extends ManagedObject {
         return alarms;
     }
 
+    /**
+     * @param me
+     * @return
+     * @throws RuntimeFault
+     * @throws RemoteException
+     */
     public AlarmState[] getAlarmState(ManagedEntity me) throws RuntimeFault, RemoteException {
         if (me == null) {
             throw new IllegalArgumentException("entity must not be null.");

--- a/src/main/java/com/vmware/vim25/mo/CertificateManager.java
+++ b/src/main/java/com/vmware/vim25/mo/CertificateManager.java
@@ -8,14 +8,14 @@ import com.vmware.vim25.mo.util.MorUtil;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/ClusterEVCManager.java
+++ b/src/main/java/com/vmware/vim25/mo/ClusterEVCManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/ExtensionManager.java
+++ b/src/main/java/com/vmware/vim25/mo/ExtensionManager.java
@@ -178,9 +178,6 @@ public class ExtensionManager extends ManagedObject {
     /**
      * Print out information of all the plugins to stdout
      *
-     * @throws RemoteException if something is wrong with web service call, either because of
-     *                         the web service itself, or because of the service provider unable
-     *                         to handle the request.
      * @deprecated
      */
     public void printAllExtensions() {

--- a/src/main/java/com/vmware/vim25/mo/GuestAliasManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestAliasManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ public class GuestAliasManager extends ManagedObject {
     /**
      * Defines an alias for a guest account in a virtual machine.
      * After the alias is defined, the ESXi Server will use the alias to authenticate guest operations requests.
-     * <p/>
+     * <p>
      * This will add the given VMWare SSO Server's certificate and a subject to the alias store of the specified
      * user in the guest. In order to add an alias to the guest, you must supply an existing valid credential.
      * This can be any instance of GuestAuthentication, but must be valid for the specified guest username.

--- a/src/main/java/com/vmware/vim25/mo/GuestWindowsRegistryManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestWindowsRegistryManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/HostAccessManager.java
+++ b/src/main/java/com/vmware/vim25/mo/HostAccessManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -64,7 +64,7 @@ public class HostAccessManager extends ManagedObject {
 
     /**
      * Changes the lockdown state of the ESXi host.
-     * <p/>
+     * <p>
      * This operation will do nothing if the host is already in the desired lockdown state.
      * When the host is in lockdown mode it can be managed only through vCenter and through DCUI
      * (Direct Console User Interface) if the DCUI service is running. This is achieved by removing all permissions on
@@ -73,17 +73,17 @@ public class HostAccessManager extends ManagedObject {
      * is disabled, the system will try to restore all permissions that have been removed when lockdown mode was
      * enabled. It is possible that not all permissions may be restored and this is not an error, e.g. if in the
      * meantime some user or managed object was deleted.
-     * <p/>
+     * <p>
      * It may be possible that after exiting lockdown mode the only permissions on the host will be those of users
      * 'dcui' and 'vpxuser'. This will render the host unmanageable if it is not already managed by vCenter, or if the
      * connection to vCenter is lost. To prevent this, the users in the "DCUI.Access" list will be assigned Admin roles.
      * While the host is in lockdown mode, some operations will fail with SecurityError. This ensures that the
      * conditions for lockdown mode cannot be changed. For example it is allowed to change the access mode only for
      * users in the exceptions list.
-     * <p/>
+     * <p>
      * When the host is in lockdown mode, changing the running state of service DCUI through HostServiceSystem will also
      * fail with SecurityError accompanied with an appropriate localizeable message.
-     * <p/>
+     * <p>
      * If mode is the same as the current lockdown mode state, the operation will silently succeed and nothing will be changed.
      * If mode is LockdownMode#lockdownDisabled then lockdown mode will be disabled and the system will start service DCUI if it is not running.
      * If mode is LockdownMode#lockdownNormal then lockdown mode will be enabled and the system will start service DCUI if it is not running.
@@ -105,7 +105,7 @@ public class HostAccessManager extends ManagedObject {
      * @return The list of users which will not lose their permissions when the host enters lockdown mode.
      * @throws RuntimeFault
      * @throws RemoteException
-     * @see {@link #updateLockdownExceptions UpdateLockdownExceptions}.
+     * @see #updateLockdownExceptions UpdateLockdownExceptions.
      */
     public String[] queryLockdownExceptions() throws RuntimeFault, RemoteException {
         return getVimService().queryLockdownExceptions(getMOR());
@@ -113,7 +113,7 @@ public class HostAccessManager extends ManagedObject {
 
     /**
      * Get the list of local system users.
-     * <p/>
+     * <p>
      * These are special users like 'vpxuser', 'vslauser' and 'dcui', which may be used for authenticating different
      * sub-components of the vSphere system and may be essential for its correct functioning.
      * Usually these users may not be used by human operators to connect directly to the host and the UI may choose to
@@ -141,13 +141,13 @@ public class HostAccessManager extends ManagedObject {
 
     /**
      * Update the list of users which are exceptions for lockdown mode.
-     * <p/>
+     * <p>
      * Usually these are user accounts used by third party solutions and external applications which need to continue to
      * function in lockdown mode. It is not advised to add user accounts used by human operators, because this will
      * compromise the purpose of lockdown mode.
-     * <p/>
+     * <p>
      * Both local and domain users are supported. The format for domain accounts is "DOMAIN\login".
-     * <p/>
+     * <p>
      * When this API is called when the host is in lockdown mode, the behaviour is as follows:
      * if a user is removed from the exceptions list, then the permissions of that user are removed.
      * if a user is added to the exceptions list, then the permissions of that user are restored.

--- a/src/main/java/com/vmware/vim25/mo/HostCertificateManager.java
+++ b/src/main/java/com/vmware/vim25/mo/HostCertificateManager.java
@@ -8,14 +8,14 @@ import com.vmware.vim25.RuntimeFault;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/HostStorageSystem.java
+++ b/src/main/java/com/vmware/vim25/mo/HostStorageSystem.java
@@ -522,7 +522,7 @@ public class HostStorageSystem extends ExtensibleManagedObject {
      * security types that require user credentials for accessing data. The password is used to acquire credentials that
      * the NFS client needs to use in order to secure NFS traffic using RPCSECGSS. The client will access files on all
      * volumes mounted on this host (that are mounted with the relevant security type) on behalf of specified user.
-     * <p/>
+     * <p>
      * At present, this API supports only file system NFSv4.1.
      *
      * @param user     Username

--- a/src/main/java/com/vmware/vim25/mo/IoFilterManager.java
+++ b/src/main/java/com/vmware/vim25/mo/IoFilterManager.java
@@ -1,14 +1,14 @@
 package com.vmware.vim25.mo;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/MessageBusProxy.java
+++ b/src/main/java/com/vmware/vim25/mo/MessageBusProxy.java
@@ -3,14 +3,14 @@ package com.vmware.vim25.mo;
 import com.vmware.vim25.ManagedObjectReference;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/OverheadMemoryManager.java
+++ b/src/main/java/com/vmware/vim25/mo/OverheadMemoryManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/SessionManager.java
+++ b/src/main/java/com/vmware/vim25/mo/SessionManager.java
@@ -93,7 +93,7 @@ public class SessionManager extends ManagedObject {
     /**
      * Copyright 2009 NetApp, contribution by Eric Forgette
      * Modified by Steve Jin (sjin@vmware.com)
-     * <p/>
+     * <p>
      * This constructor builds a new ServiceInstance based on a ServiceInstance.
      * The new ServiceInstance is effectively a clone of the first.  This clone will
      * NOT become invalid when the first is logged out.

--- a/src/main/java/com/vmware/vim25/mo/Task.java
+++ b/src/main/java/com/vmware/vim25/mo/Task.java
@@ -114,10 +114,10 @@ public class Task extends ExtensibleManagedObject {
 
     /**
      * Copyright 2009 NetApp, contribution by Eric Forgette
-     * <p/>
+     * <p>
      * This is a "drop-in" replacement for waitForMe() that uses a timed polling
      * in place of waitForValues.
-     * <p/>
+     * <p>
      * This method will eat 3 exceptions while trying to get TaskInfo and TaskState.
      * On the fourth try, the captured exception is thrown.
      *
@@ -134,7 +134,7 @@ public class Task extends ExtensibleManagedObject {
 
     /**
      * Copyright 2009 NetApp, contribution by Eric Forgette
-     * <p/>
+     * <p>
      * This is a replacement for waitForMe() that uses a timed polling
      * in place of waitForValues.  The delay between each poll is
      * configurable based on the last seen task state.  The method will sleep
@@ -142,7 +142,7 @@ public class Task extends ExtensibleManagedObject {
      * while the task is in the running state.
      * The method will sleep for the number of milliseconds specified
      * in queuedDelayInMillSecond while the task is in the queued state.
-     * <p/>
+     * <p>
      * This method will eat 3 exceptions while trying to get TaskInfo and TaskState.
      * On the fourth try, the captured exception is thrown.
      *

--- a/src/main/java/com/vmware/vim25/mo/VRPResourceManager.java
+++ b/src/main/java/com/vmware/vim25/mo/VRPResourceManager.java
@@ -5,14 +5,14 @@ import com.vmware.vim25.*;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/mo/VirtualDiskManager.java
+++ b/src/main/java/com/vmware/vim25/mo/VirtualDiskManager.java
@@ -139,13 +139,13 @@ public class VirtualDiskManager extends ManagedObject {
 
     /**
      * Import an unmanaged-snapshot from Virtual-Volume(VVol) enabled Storage Array.
-     * <p/>
+     * <p>
      * Storage Array may support users to take snapshots indepedent of VMware stack. Such copies or snapshots are known
      * as 'Unmanaged-Snapshots'. We are providing an ability to end-users to import such unmanaged-snapshots as Virtual
      * Disks.
-     * <p/>
+     * <p>
      * End-user needs to know the VVol-Identifier to import unmanaged snapshot as VirtualDisk.
-     * <p/>
+     * <p>
      * Once VirtualDisk is created, user can use 'Datastore Browser' to use with rest of Virtual Machine provisioning
      * APIs.
      *

--- a/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
+++ b/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
@@ -199,13 +199,13 @@ public class VirtualMachine extends ManagedEntity {
 
     /**
      * Creates a secondary virtual machine to be part of this fault tolerant group.
-     * <p/>
+     * <p>
      * If a host is specified, the secondary virtual machine will be created on it. Otherwise, a host will be selected
      * by the system.
-     * <p/>
+     * <p>
      * If a FaultToleranceConfigSpec is specified, the virtual machine's configuration files and disks will be created
      * in the specified datastores.
-     * <p/>
+     * <p>
      * If the primary virtual machine (i.e., this virtual machine) is powered on when the secondary is created, an
      * attempt will be made to power on the secondary on a system selected host. If the cluster is a DRS cluster, DRS
      * will be invoked to obtain a placement for the new secondary virtual machine. If the DRS recommendation

--- a/src/main/java/com/vmware/vim25/mo/VsanUpgradeSystem.java
+++ b/src/main/java/com/vmware/vim25/mo/VsanUpgradeSystem.java
@@ -6,14 +6,14 @@ import com.vmware.vim25.mo.util.MorUtil;
 import java.rmi.RemoteException;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ public class VsanUpgradeSystem extends ManagedObject {
      * @throws RuntimeFault
      * @throws VsanFault
      * @throws RemoteException
-     * @see {@link #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck}
+     * @see #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck
      */
     public Task performVsanUpgrade_Task(ClusterComputeResource cluster, Boolean performObjectUpgrade,
                                         Boolean downgradeFormat, Boolean allowReducedRedundancy, HostSystem[] excludeHosts)
@@ -88,7 +88,7 @@ public class VsanUpgradeSystem extends ManagedObject {
      * @throws RuntimeFault
      * @throws VsanFault
      * @throws RemoteException
-     * @see {@link #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck}
+     * @see #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck
      */
     public Task performVsanUpgrade_Task(ClusterComputeResource cluster, Boolean performObjectUpgrade,
                                         Boolean downgradeFormat, Boolean allowReducedRedundancy)
@@ -119,7 +119,7 @@ public class VsanUpgradeSystem extends ManagedObject {
      * @throws RuntimeFault
      * @throws VsanFault
      * @throws RemoteException
-     * @see {@link #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck}
+     * @see #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck
      */
     public Task performVsanUpgrade_Task(ClusterComputeResource cluster, Boolean performObjectUpgrade, Boolean downgradeFormat)
         throws RuntimeFault, VsanFault, RemoteException {
@@ -148,7 +148,7 @@ public class VsanUpgradeSystem extends ManagedObject {
      * @throws RuntimeFault
      * @throws VsanFault
      * @throws RemoteException
-     * @see {@link #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck}
+     * @see #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck
      */
     public Task performVsanUpgrade_Task(ClusterComputeResource cluster, Boolean performObjectUpgrade) throws RuntimeFault, VsanFault, RemoteException {
         return performVsanUpgrade_Task(cluster, performObjectUpgrade, null, null, null);
@@ -175,7 +175,7 @@ public class VsanUpgradeSystem extends ManagedObject {
      * @throws RuntimeFault
      * @throws VsanFault
      * @throws RemoteException
-     * @see {@link #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck}
+     * @see #performVsanUpgradePreflightCheck performVsanUpgradePreflightCheck
      */
     public Task performVsanUpgrade_Task(ClusterComputeResource cluster) throws RuntimeFault, VsanFault, RemoteException {
         return performVsanUpgrade_Task(cluster, null, null, null, null);

--- a/src/main/java/com/vmware/vim25/mo/util/VerUtil.java
+++ b/src/main/java/com/vmware/vim25/mo/util/VerUtil.java
@@ -42,8 +42,8 @@ import java.security.cert.X509Certificate;
 
 /**
  * The returned XML data is in the following format:
- * <p/>
  * <pre>
+ * {@code
  * <?xml version="1.0" encoding="UTF-8" ?>
  * <!--
  * Copyright 2005-2007 VMware, Inc.  All rights reserved.
@@ -60,8 +60,9 @@ import java.security.cert.X509Certificate;
  *     </port>
  *  </service>
  * </definitions>
+ * }
  * </pre>
- * <p/>
+ * <p>
  * Utility class for checking the version of VISDK the server supports.
  *
  * @author Steve JIN (sjin@vmware.com)

--- a/src/main/java/com/vmware/vim25/mox/VirtualMachineDeviceManager.java
+++ b/src/main/java/com/vmware/vim25/mox/VirtualMachineDeviceManager.java
@@ -102,7 +102,7 @@ import org.apache.log4j.Logger;
  * VirtualMachineDeviceManager manages the virtual devices in a much
  * simplified way than using the reconfigVM_Task() method defined in
  * VirtualMachine managed object.
- * <p/>
+ * <p>
  * Devices it manages include: FloppyDrive, CdDrive, NetworkAdapter, UsbDevice, HardDisk
  * Operations include:
  * create -- create something new

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -22,15 +22,15 @@ import java.rmi.RemoteException;
 
 /**
  * Created by Michael Rice on 8/12/14.
- * <p/>
+ * <p>
  * Copyright 2014 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ public class ApacheHttpClient extends SoapClient {
 
     /**
      * Trust all the ssl stuff no matter what!?!
-     * <p/>
+     * <p>
      * We do true here because by default all the vsphere stuff
      * is self signed.
      */
@@ -88,10 +88,10 @@ public class ApacheHttpClient extends SoapClient {
      * This method typically creates the payload needed to send to the vi server. For example you would
      * pass in RetrieveServiceContent for the methodName, next the params needed for the method. Next give
      * the returnType the parser should convert the response to in this case the string ServiceContent
-     * <p/>
+     * <p>
      * Returns an {@link Object} of the given return type. Using the example above you would get
      * a {@link com.vmware.vim25.ServiceContent} Object.
-     * <p/>
+     * <p>
      *
      * @param methodName Name of the method to execute
      * @param paras      Array of Arguments aka params for the method

--- a/src/main/java/com/vmware/vim25/ws/ApacheTrustSelfSigned.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheTrustSelfSigned.java
@@ -12,15 +12,15 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * Created by Michael Rice on 8/15/14.
- * <p/>
+ * <p>
  * Copyright 2014 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/ws/Client.java
+++ b/src/main/java/com/vmware/vim25/ws/Client.java
@@ -11,9 +11,9 @@ import java.rmi.RemoteException;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,10 +28,10 @@ public interface Client {
      * This method typically creates the payload needed to send to the vi server. For example you would
      * pass in RetrieveServiceContent for the methodName, next the params needed for the method. Next give
      * the returnType the parser should convert the response to in this case the string ServiceContent
-     * <p/>
+     * <p>
      * Returns an {@link java.lang.Object} of the given return type. Using the example above you would get
      * a {@link com.vmware.vim25.ServiceContent} Object.
-     * <p/>
+     * <p>
      *
      * @param methodName Name of the method to execute
      * @param paras      Array of Arguments aka params for the method
@@ -111,7 +111,7 @@ public interface Client {
      * java.net.SocketTimeoutException is raised. A timeout of zero is
      * interpreted as an infinite timeout. This is only used if your
      * client supports this setting.
-     * <p/>
+     * <p>
      * <p> Some non-standard implmentation of this method may ignore
      * the specified timeout. To see the connect timeout set, please
      * call getConnectTimeout().
@@ -122,7 +122,7 @@ public interface Client {
 
     /**
      * Returns the time in milliseconds that is set for the read timeout
-     * <p/>
+     * <p>
      * This time may not be the same as what the underlying client uses. If
      * for example the client does not support this and is for some reason
      * hard coded to some value this value.
@@ -133,14 +133,14 @@ public interface Client {
 
     /**
      * Set the read timeout.
-     * <p/>
+     * <p>
      * Sets the read timeout to a specified timeout, in milliseconds.
      * A non-zero value specifies the timeout when reading from Input
      * stream when a connection is established to a resource. If the
      * timeout expires before there is data available for read, a
      * java.net.SocketTimeoutException is raised. A timeout of zero
      * is interpreted as an infinite timeout.
-     * <p/>
+     * <p>
      * This value will be used by the underlying http client used if
      * it is supported. By default that is the WSClient which uses
      * HTTPURLConnection which uses URLConnection

--- a/src/main/java/com/vmware/vim25/ws/ClientCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/ClientCreator.java
@@ -5,15 +5,15 @@ import java.lang.reflect.InvocationTargetException;
 
 /**
  * Created by Michael Rice on 8/11/14.
- * <p/>
+ * <p>
  * Copyright 2014 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/ws/SoapAction.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapAction.java
@@ -2,15 +2,15 @@ package com.vmware.vim25.ws;
 
 /**
  * Created by Michael Rice on 8/9/14.
- * <p/>
+ * <p>
  * Copyright 2014 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -11,15 +11,15 @@ import java.net.URL;
 
 /**
  * Created by Michael Rice on 8/10/14.
- * <p/>
+ * <p>
  * Copyright 2014 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -140,7 +140,7 @@ public abstract class SoapClient implements Client {
 
     /**
      * Returns the time in milliseconds that is set for the read timeout
-     * <p/>
+     * <p>
      * This time may not be the same as what the underlying client uses. If
      * for example the client does not support this and is for some reason
      * hard coded to some value this value.
@@ -153,14 +153,14 @@ public abstract class SoapClient implements Client {
 
     /**
      * Set the read timeout.
-     * <p/>
+     * <p>
      * Sets the read timeout to a specified timeout, in milliseconds.
      * A non-zero value specifies the timeout when reading from Input
      * stream when a connection is established to a resource. If the
      * timeout expires before there is data available for read, a
      * java.net.SocketTimeoutException is raised. A timeout of zero
      * is interpreted as an infinite timeout.
-     * <p/>
+     * <p>
      * This value will be used by the underlying http client used if
      * it is supported. By default that is the WSClient which uses
      * HTTPURLConnection which uses URLConnection

--- a/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
+++ b/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
@@ -13,9 +13,9 @@ import java.security.cert.X509Certificate;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/TypeUtilTest.java
+++ b/src/test/java/org/doublecloud/ws/util/TypeUtilTest.java
@@ -2,15 +2,15 @@ package org.doublecloud.ws.util;
 
 /**
  * Created by Michael Rice on 2/12/15.
- * <p/>
+ * <p>
  * Copyright 2015 Michael Rice
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilAbsClass1Field.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilAbsClass1Field.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilExtendsAbs1With2Fields.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilExtendsAbs1With2Fields.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilExtendsSuper4Fields.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilExtendsSuper4Fields.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilImplementsSimpleWith4Fields.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilImplementsSimpleWith4Fields.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSimpleInterfaceWith2Fields1Method.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSimpleInterfaceWith2Fields1Method.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSingleObjWith2Fields1Method.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSingleObjWith2Fields1Method.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSuperClassWith2Fields.java
+++ b/src/test/java/org/doublecloud/ws/util/testUtils/ReflectUtilSuperClassWith2Fields.java
@@ -1,14 +1,14 @@
 package org.doublecloud.ws.util.testUtils;
 
 /**
- * Copyright 2015 Michael Rice <michael@michaelrice.org>
- * <p/>
+ * Copyright 2015 Michael Rice &lt;michael@michaelrice.org&gt;
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
complains about malformed HTML when using < >.

Replace self-closing paragraph tags <p/> with open paragraph tag <p>.
Java 8 will not accept self-closing tags but is happy to automatically
close open tags.

Eliminate useless <p> and add {@code} to properly display XML content in Javadoc.

Javadoc automatically handles creation of links when using @see. Remove explicit {@link} to prevent Java8 from throwing an error.

In-progress javadoc on AlarmManager.

Remove documented but not thrown exception.
