### PR TITLE
Fix for trust manager regression introduced by changes for #38 and #123

### DIFF
--- a/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
@@ -259,15 +259,15 @@ public class WSClientIntTest {
          * {@inheritDoc}
          */
         @Override
-        protected SSLSocketFactory getSocketFactory(boolean ignoreCert) throws RemoteException {
+        protected SSLSocketFactory getTrustAllSocketFactory(boolean ignoreCert) throws RemoteException {
             ++createdSSLFactory;
-            return super.getSocketFactory(ignoreCert);
+            return super.getTrustAllSocketFactory(ignoreCert);
         }
 
         @Override
-        protected SSLSocketFactory getSocketFactory(TrustManager trustManager) throws RemoteException {
+        protected SSLSocketFactory getCustomTrustManagerSocketFactory(TrustManager trustManager) throws RemoteException {
             ++createdSSLFactory;
-            return super.getSocketFactory(trustManager);
+            return super.getCustomTrustManagerSocketFactory(trustManager);
         }
     }
 

--- a/src/main/java/com/vmware/vim25/VimPortType.java
+++ b/src/main/java/com/vmware/vim25/VimPortType.java
@@ -32,9 +32,15 @@ package com.vmware.vim25;
 
 import com.vmware.vim25.ws.Client;
 
+import javax.net.ssl.TrustManager;
+
 public class VimPortType extends com.vmware.vim25.ws.VimStub {
     public VimPortType(String url, boolean ignoreCert) throws java.net.MalformedURLException {
         super(url, ignoreCert);
+    }
+
+    public VimPortType(String url, TrustManager trustManager) {
+        super(url, trustManager);
     }
 
     public VimPortType(Client url) throws java.net.MalformedURLException {

--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -117,12 +117,11 @@ public class ServiceInstance extends ManagedObject {
 
         setMOR(SERVICE_INSTANCE_MOR);
 
-        VimPortType vimService = new VimPortType(url.toString(), ignoreCert);
+        VimPortType vimService = trustManager != null ? new VimPortType(url.toString(), trustManager) : new VimPortType(url.toString(), ignoreCert);
         vimService.getWsc().setVimNameSpace(namespace);
 
         vimService.getWsc().setConnectTimeout(connectTimeout);
         vimService.getWsc().setReadTimeout(readTimeout);
-        vimService.getWsc().setTrustManager(trustManager);
 
         serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
         vimService.getWsc().setSoapActionOnApiVersion(getApiVersion(serviceContent));
@@ -183,14 +182,13 @@ public class ServiceInstance extends ManagedObject {
 
         setMOR(SERVICE_INSTANCE_MOR);
 
-        VimPortType vimService = new VimPortType(url.toString(), ignoreCert);
+        VimPortType vimService = trustManager != null ? new VimPortType(url.toString(), trustManager) : new VimPortType(url.toString(), ignoreCert);
         Client wsc = vimService.getWsc();
         wsc.setCookie(sessionStr);
         wsc.setVimNameSpace(namespace);
 
         vimService.getWsc().setConnectTimeout(connectTimeout);
         vimService.getWsc().setReadTimeout(readTimeout);
-        vimService.getWsc().setTrustManager(trustManager);
 
         serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
         wsc.setSoapActionOnApiVersion(getApiVersion(serviceContent));

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -12,6 +12,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.log4j.Logger;
 
+import javax.net.ssl.TrustManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -48,7 +49,7 @@ public class ApacheHttpClient extends SoapClient {
     /**
      * The XML serialization/de-serialization engine
      */
-    XmlGen xmlGen = new XmlGenDom();
+    private XmlGen xmlGen = new XmlGenDom();
 
     /**
      * Trust all the ssl stuff no matter what!?!
@@ -66,12 +67,18 @@ public class ApacheHttpClient extends SoapClient {
      * @throws MalformedURLException
      */
     public ApacheHttpClient(String serverUrl, boolean ignoreCert) throws MalformedURLException {
+        this(serverUrl, ignoreCert, null);
+    }
+
+    public ApacheHttpClient(String serverUrl, boolean ignoreCert, TrustManager trustManager) throws MalformedURLException {
         if (serverUrl.endsWith("/")) {
             serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
         }
-        trustAllSSL = ignoreCert;
+
         log.trace("Creating ApacheHttpClient to server URL: " + serverUrl);
         log.trace("Ignore ssl: " + ignoreCert);
+        this.trustAllSSL = ignoreCert;
+        this.trustManager = trustManager;
         this.baseUrl = new URL(serverUrl);
     }
 
@@ -205,4 +212,5 @@ public class ApacheHttpClient extends SoapClient {
         }
         return inputStream;
     }
+
 }

--- a/src/main/java/com/vmware/vim25/ws/Client.java
+++ b/src/main/java/com/vmware/vim25/ws/Client.java
@@ -151,8 +151,6 @@ public interface Client {
 
     public TrustManager getTrustManager();
 
-    public void setTrustManager(TrustManager trustManager);
-
     /**
      * Sets the api version. The oldest supported will be v4.0
      *

--- a/src/main/java/com/vmware/vim25/ws/ClientCreator.java
+++ b/src/main/java/com/vmware/vim25/ws/ClientCreator.java
@@ -1,5 +1,6 @@
 package com.vmware.vim25.ws;
 
+import javax.net.ssl.TrustManager;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
@@ -26,6 +27,11 @@ final public class ClientCreator {
 
     public static Client getClient(String url, boolean ignoreCert) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<?> constructor = clientClass.getConstructor(String.class, boolean.class);
-        return (Client) constructor.newInstance(new Object[]{url, ignoreCert});
+        return (Client) constructor.newInstance(url, ignoreCert);
+    }
+
+    public static Client getClient(String url, TrustManager trustManager) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<?> constructor = clientClass.getConstructor(String.class, boolean.class, TrustManager.class);
+        return (Client) constructor.newInstance(url, false, trustManager);
     }
 }

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -175,15 +175,6 @@ public abstract class SoapClient implements Client {
         return trustManager;
     }
 
-    /**
-     * Set a custom trust manager responsible for material used when making trust decisions.
-     *
-     * @param trustManager
-     */
-    public void setTrustManager(TrustManager trustManager) {
-        this.trustManager = trustManager;
-    }
-
     public StringBuffer readStream(InputStream is) throws IOException {
         log.trace("Building StringBuffer from InputStream response.");
         StringBuffer sb = new StringBuffer();

--- a/src/main/java/com/vmware/vim25/ws/VimStub.java
+++ b/src/main/java/com/vmware/vim25/ws/VimStub.java
@@ -30,9 +30,9 @@ POSSIBILITY OF SUCH DAMAGE.
 package com.vmware.vim25.ws;
 
 import com.vmware.vim25.*;
-import com.vmware.vim25.mo.ManagedObject;
 import org.apache.log4j.Logger;
 
+import javax.net.ssl.TrustManager;
 import java.lang.reflect.InvocationTargetException;
 import java.rmi.RemoteException;
 import java.util.Calendar;
@@ -51,7 +51,7 @@ public class VimStub {
      */
     private static Logger log = Logger.getLogger(VimStub.class);
 
-    public VimStub(String url, boolean ignoreCert) throws java.net.MalformedURLException {
+    public VimStub(String url, boolean ignoreCert) {
         try {
             this.wsc = ClientCreator.getClient(url, ignoreCert);
         }
@@ -66,6 +66,14 @@ public class VimStub {
         }
         catch (InstantiationException e) {
             log.error("Error detected for url: " + url + " ignoreSSL: " + ignoreCert, e);
+        }
+    }
+
+    public VimStub(String url, TrustManager trustManager) {
+        try {
+            this.wsc = ClientCreator.getClient(url, trustManager);
+        } catch (ReflectiveOperationException e) {
+            log.error("Error detected for url: " + url + " trustManager: " + trustManager, e);
         }
     }
 

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -35,6 +35,7 @@ import org.apache.log4j.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -55,20 +56,30 @@ public class WSClient extends SoapClient {
     private static final Logger log = Logger.getLogger(WSClient.class);
     private final SSLSocketFactory sslSocketFactory;
 
-    XmlGen xmlGen = new XmlGenDom();
+    private XmlGen xmlGen = new XmlGenDom();
 
     public WSClient(String serverUrl) throws MalformedURLException, RemoteException {
         this(serverUrl, true);
     }
 
     public WSClient(String serverUrl, boolean ignoreCert) throws MalformedURLException, RemoteException {
+        this(serverUrl, ignoreCert, null);
+    }
+
+    public WSClient(String serverUrl, boolean ignoreCert, TrustManager trustManager) throws MalformedURLException, RemoteException {
+        if(ignoreCert && trustManager != null) {
+            log.warn("The option to ignore certs has been set along with a provided trust manager. This is not a valid scenario and the trust manager will be ignored.");
+        }
+
         if (serverUrl.endsWith("/")) {
             serverUrl = serverUrl.substring(0, serverUrl.length() - 1);
         }
         log.trace("Creating WSClient to server URL: " + serverUrl);
         log.trace("Ignore ssl: " + ignoreCert);
+
+        this.trustManager = trustManager;
         this.baseUrl = new URL(serverUrl);
-        this.sslSocketFactory = getSocketFactory(ignoreCert);
+        this.sslSocketFactory = ignoreCert ? getSocketFactory(true) : getSocketFactory(trustManager);
     }
 
     public Object invoke(String methodName, Argument[] paras, String returnType) throws RemoteException {
@@ -196,5 +207,9 @@ public class WSClient extends SoapClient {
 
     protected SSLSocketFactory getSocketFactory(boolean ignoreCert) throws RemoteException {
         return ignoreCert ? TrustAllSSL.getTrustContext().getSocketFactory() : null;
+    }
+
+    protected SSLSocketFactory getSocketFactory(TrustManager tm) throws RemoteException {
+        return tm != null ? CustomSSLTrustContextCreator.getTrustContext(tm).getSocketFactory() : null;
     }
 }

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -79,7 +79,7 @@ public class WSClient extends SoapClient {
 
         this.trustManager = trustManager;
         this.baseUrl = new URL(serverUrl);
-        this.sslSocketFactory = ignoreCert ? getSocketFactory(true) : getSocketFactory(trustManager);
+        this.sslSocketFactory = ignoreCert ? getTrustAllSocketFactory(true) : getCustomTrustManagerSocketFactory(trustManager);
     }
 
     public Object invoke(String methodName, Argument[] paras, String returnType) throws RemoteException {
@@ -205,11 +205,11 @@ public class WSClient extends SoapClient {
         return new OutputStreamWriter(os, "UTF8");
     }
 
-    protected SSLSocketFactory getSocketFactory(boolean ignoreCert) throws RemoteException {
+    protected SSLSocketFactory getTrustAllSocketFactory(boolean ignoreCert) throws RemoteException {
         return ignoreCert ? TrustAllSSL.getTrustContext().getSocketFactory() : null;
     }
 
-    protected SSLSocketFactory getSocketFactory(TrustManager tm) throws RemoteException {
+    protected SSLSocketFactory getCustomTrustManagerSocketFactory(TrustManager tm) throws RemoteException {
         return tm != null ? CustomSSLTrustContextCreator.getTrustContext(tm).getSocketFactory() : null;
     }
 }


### PR DESCRIPTION
I had to pass the trust manager to the WSClient constructor in order to set it on the ssl socket factory where it is now created. All tests are now passing for me and i've performed some testing with our product. 

This should allow trust manager to be used along with keeping the performance fix for creating the ssl socket factory.
