### PR TITLE
Add the detailed message to the soap fault exception

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -46,6 +46,7 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.rmi.RemoteException;
+import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -157,7 +158,7 @@ class XmlGenDom extends XmlGen {
         }
     }
 
-    private static Object setDetailMessageInException(Object obj, String detailMessage) {
+    protected static Object setDetailMessageInException(Object obj, String detailMessage) {
         Class current = obj.getClass();
         while(current != null) {
             try{
@@ -171,6 +172,9 @@ class XmlGenDom extends XmlGen {
             } catch (NoSuchFieldException e) {
                 current = current.getSuperclass();
             } catch (IllegalAccessException e) {
+                log.info("The fault string: \"" + detailMessage + "\", was unable to be set in exception due to: ", e);
+                return obj;
+            } catch (AccessControlException e) {
                 log.info("The fault string: \"" + detailMessage + "\", was unable to be set in exception due to: ", e);
                 return obj;
             }


### PR DESCRIPTION
This will populate the "detail" field in the soap fault exception class to also include the fault string. This will help improve fault handling and logging.
