### PR TITLE
Retrieve the SSL thumbprint of the peer ESXi/vCenter server

### DIFF
--- a/src/intTest/java/VcenterInfo.properties
+++ b/src/intTest/java/VcenterInfo.properties
@@ -2,5 +2,6 @@ url=https://172.16.214.143/sdk
 secondUrl=https://172.16.214.146/sdk
 username=administrator@vsphere.local
 password=password
+sslThumbprint=92:72:1B:6A:DD:24:3D:64:BE:73:2A:53:B4:70:2D:AA:78:99:1B:B8
 # This bad url should be to any site with an untrusted ssl cert
 badUrl=https://jenkins.toastcoders.com/

--- a/src/intTest/java/com/utility/LoadVcenterProps.java
+++ b/src/intTest/java/com/utility/LoadVcenterProps.java
@@ -11,6 +11,7 @@ public class LoadVcenterProps {
     public static String password;
     public static String secondUrl;
     public static String badUrl;
+    public static String sslThumbprint;
 
     static {
         InputStream input = null;
@@ -28,6 +29,7 @@ public class LoadVcenterProps {
             password = prop.getProperty("password");
             secondUrl = prop.getProperty("secondUrl");
             badUrl = prop.getProperty("badUrl");
+            sslThumbprint = prop.getProperty("sslThumbprint");
 
         } catch (IOException ex) {
             ex.printStackTrace();

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -8,10 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-import java.security.cert.CertificateEncodingException;
 
 /**
  * Created by Michael Rice on 8/10/14.
@@ -36,7 +32,6 @@ public abstract class SoapClient implements Client {
     public String soapAction;
     public URL baseUrl = null;
     public String cookie = null;
-    public String thumbprint = null;
     public String vimNameSpace = null;
     public int connectTimeout = 0;
     public int readTimeout = 0;
@@ -107,36 +102,6 @@ public abstract class SoapClient implements Client {
      */
     public String getCookie() {
         return cookie;
-    }
-
-    public String getServerThumbprint() {
-        return thumbprint;
-    }
-
-    public static String computeX509CertificateThumbprint(X509Certificate cert){
-	try {
-	    MessageDigest md = MessageDigest.getInstance("SHA-1");
-	    return hexify(md.digest(cert.getEncoded()));
-	}
-	catch (NoSuchAlgorithmException ignore1) {
-	    return null;
-	}
-	catch (CertificateEncodingException ignore2) {
-	    return null;
-	}
-    }
-
-    public static String hexify (byte bytes[]) {
-	char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-	    'A', 'B', 'C', 'D', 'E', 'F'};
-
-	StringBuffer buf = new StringBuffer(bytes.length * 3);
-	for (int i = 0; i < bytes.length; i++) {
-	    if (i != 0) buf.append(':');
-	    buf.append(hexDigits[(bytes[i] & 0xf0) >> 4]);
-	    buf.append(hexDigits[bytes[i] & 0x0f]);
-	}
-	return buf.toString();
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -8,6 +8,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateEncodingException;
 
 /**
  * Created by Michael Rice on 8/10/14.
@@ -32,6 +36,7 @@ public abstract class SoapClient implements Client {
     public String soapAction;
     public URL baseUrl = null;
     public String cookie = null;
+    public String thumbprint = null;
     public String vimNameSpace = null;
     public int connectTimeout = 0;
     public int readTimeout = 0;
@@ -102,6 +107,36 @@ public abstract class SoapClient implements Client {
      */
     public String getCookie() {
         return cookie;
+    }
+
+    public String getServerThumbprint() {
+        return thumbprint;
+    }
+
+    public static String computeX509CertificateThumbprint(X509Certificate cert){
+	try {
+	    MessageDigest md = MessageDigest.getInstance("SHA-1");
+	    return hexify(md.digest(cert.getEncoded()));
+	}
+	catch (NoSuchAlgorithmException ignore1) {
+	    return null;
+	}
+	catch (CertificateEncodingException ignore2) {
+	    return null;
+	}
+    }
+
+    public static String hexify (byte bytes[]) {
+	char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+	    'A', 'B', 'C', 'D', 'E', 'F'};
+
+	StringBuffer buf = new StringBuffer(bytes.length * 3);
+	for (int i = 0; i < bytes.length; i++) {
+	    if (i != 0) buf.append(':');
+	    buf.append(hexDigits[(bytes[i] & 0xf0) >> 4]);
+	    buf.append(hexDigits[bytes[i] & 0x0f]);
+	}
+	return buf.toString();
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -8,6 +8,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.security.cert.CertificateEncodingException;
 
 /**
  * Created by Michael Rice on 8/10/14.
@@ -32,6 +36,7 @@ public abstract class SoapClient implements Client {
     public String soapAction;
     public URL baseUrl = null;
     public String cookie = null;
+    public String thumbprint = null;
     public String vimNameSpace = null;
     public int connectTimeout = 0;
     public int readTimeout = 0;
@@ -102,6 +107,40 @@ public abstract class SoapClient implements Client {
      */
     public String getCookie() {
         return cookie;
+    }
+
+    public void setServerThumbprint(String thumbprint) {
+        this.thumbprint = thumbprint;
+    }
+
+    public String getServerThumbprint() {
+        return thumbprint;
+    }
+
+    public static String computeX509CertificateThumbprint(X509Certificate cert){
+	try {
+	    MessageDigest md = MessageDigest.getInstance("SHA-1");
+	    return hexify(md.digest(cert.getEncoded()));
+	}
+	catch (NoSuchAlgorithmException ignore1) {
+	    return null;
+	}
+	catch (CertificateEncodingException ignore2) {
+	    return null;
+	}
+    }
+
+    public static String hexify (byte bytes[]) {
+	char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+	    'A', 'B', 'C', 'D', 'E', 'F'};
+
+	StringBuffer buf = new StringBuffer(bytes.length * 3);
+	for (int i = 0; i < bytes.length; i++) {
+	    if (i != 0) buf.append(':');
+	    buf.append(hexDigits[(bytes[i] & 0xf0) >> 4]);
+	    buf.append(hexDigits[bytes[i] & 0x0f]);
+	}
+	return buf.toString();
     }
 
     /**

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -34,7 +34,6 @@ package com.vmware.vim25.ws;
 import org.apache.log4j.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import java.io.*;
@@ -44,8 +43,6 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.rmi.RemoteException;
 import java.text.MessageFormat;
-import java.security.cert.Certificate;
-import java.security.cert.X509Certificate;
 
 /**
  * The Web Service Engine
@@ -201,20 +198,6 @@ public class WSClient extends SoapClient {
             }
         }
 
-        if (thumbprint == null && postCon instanceof HttpsURLConnection) {
-	    try {
-		Certificate[] certs = ((HttpsURLConnection)postCon).
-		    getServerCertificates();
-		for (int i = 0; thumbprint == null && i < certs.length; i++) {
-		    if (certs[i] instanceof X509Certificate)
-			thumbprint = computeX509CertificateThumbprint(
-			    (X509Certificate) certs[i]);
-		}
-	    }
-	    catch (SSLPeerUnverifiedException e) {
-                log.debug("SSLPeerUnverifiedException caught.", e);
-	    }
-        }
         return is;
     }
 

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -34,6 +34,7 @@ package com.vmware.vim25.ws;
 import org.apache.log4j.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import java.io.*;
@@ -43,6 +44,8 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.rmi.RemoteException;
 import java.text.MessageFormat;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 
 /**
  * The Web Service Engine
@@ -198,6 +201,20 @@ public class WSClient extends SoapClient {
             }
         }
 
+        if (thumbprint == null && postCon instanceof HttpsURLConnection) {
+	    try {
+		Certificate[] certs = ((HttpsURLConnection)postCon).
+		    getServerCertificates();
+		for (int i = 0; thumbprint == null && i < certs.length; i++) {
+		    if (certs[i] instanceof X509Certificate)
+			thumbprint = computeX509CertificateThumbprint(
+			    (X509Certificate) certs[i]);
+		}
+	    }
+	    catch (SSLPeerUnverifiedException e) {
+                log.debug("SSLPeerUnverifiedException caught.", e);
+	    }
+        }
         return is;
     }
 


### PR DESCRIPTION
The code computes the SSL thumbprint on the first request to the ESXi or vCenter server.
The integration tests are included.

This is a followup to #141  
