### PR TITLE
Prevent java.lang.IllegalAccessException in java.util.Calendar in some cases where getPackage doesn't act like a flyweight

### DIFF
--- a/src/main/java/org/doublecloud/ws/util/TypeUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/TypeUtil.java
@@ -78,12 +78,12 @@ public class TypeUtil {
         return false;
     }
 
-    final private static Package LANG_PKG = String.class.getPackage();
-    final private static Package UTIL_PKG = Calendar.class.getPackage();
+    final private static String LANG_PKG = String.class.getPackage().getName();
+    final private static String UTIL_PKG = Calendar.class.getPackage().getName();
 
     public static boolean isBasicType(Class<?> clazz) {
         Package pkg = clazz.getPackage(); // for primitive type like int, the pkg is null
-        return pkg == null || pkg == LANG_PKG || pkg == UTIL_PKG;
+        return pkg == null || pkg.getName().equals(LANG_PKG) || pkg.getName().equals(UTIL_PKG);
     }
 
     private static String PACKAGE_NAME = "com.vmware.vim25";


### PR DESCRIPTION
In relation to yavijava/yavijava#153.  Basically use string comparison to compare java.util and java.lang because getPackage() appears to not always be a flyweight (eg doesn't necessarily return the same object if the package is that same).  I think this can happen if a classloader is present and it definitely happens in Jython servlets with ModjyJServlet; I guess it would happen with others.
