### PR TITLE
Ensure NPE does not occur when an XML type does not map to a vim clas…

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -232,9 +232,14 @@ class XmlGenDom extends XmlGen {
                 Array.set(ao, i, o);
             }
             return ao;
-        }
-        else {
-            return fromXml(TypeUtil.getVimClass(type), subNodes.get(0));
+        } else {
+            Class<?> vimClass = TypeUtil.getVimClass(type);
+            if(vimClass != null) {
+                return fromXml(vimClass, subNodes.get(0));
+            } else {
+                log.error("Vim class not found for type: " + type + ", XML Document: " + subNodes.get(0).asXML());
+                return null;
+            }
         }
     }
 

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -14,6 +14,15 @@ import java.util.Objects;
 
 public class XmlGenDomTest {
 
+    @Test
+    public void testFromXML_UnknownClass() throws Exception {
+        // simulate with non-existing class
+        InputStream inputStream = new FileInputStream(new File("src/test/resources/xml/UnknownConfigSpec.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        Object nullObject = xmlGenDom.fromXML("UnknownConfigSpec", inputStream);
+        assert nullObject == null;
+    }
+
     @Test(expected = InvalidLogin.class)
     public void testFromXML_Throws_Invalid_Login_When_Login_is_Invalid() throws Exception {
         InputStream inputStream = new FileInputStream(new File("src/test/java/com/vmware/vim25/ws/xml/InvalidLoginFault.xml"));

--- a/src/test/resources/xml/UnknownConfigSpec.xml
+++ b/src/test/resources/xml/UnknownConfigSpec.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <RetrievePropertiesResponse xmlns="urn:vim25">
+            <returnval><obj type="VirtualMachine">vm-9</obj><propSet><name>config</name><val xsi:type="UnknownConfigSpec"></val></propSet></returnval>
+        </RetrievePropertiesResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
…s, also log received XML in these cases

We've encountered some cases where we receive an XML payload for a type that has no matching vim class. This caused a NullPointerException and failed our collection and synchronization of vCenter inventory. Ive made this change to no longer pass the null vim class to the fromXml() method which caused the NPE. When this case happens the XML will be logged out so a new class can be created if desired. The downside to this is that you could have a class inconsistency but i think that is a better alternative than failing with a NPE. When there is an inconsistency we can add the missing class to support new vSphere objects.
