### PR TITLE
Wraps log statement with isTraceEnabled

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -79,7 +79,9 @@ class XmlGenDom extends XmlGen {
         try {
             SAXReader reader = new SAXReader();
             Document doc = reader.read(is);
-            log.trace("XML Document: " + doc.asXML());
+            if(log.isTraceEnabled()) {
+                log.trace("XML Document: " + doc.asXML());
+            }
             root = doc.getRootElement();
         }
         catch (DocumentException e){


### PR DESCRIPTION
This commit wraps a taxing trace log statement
with isTraceEnabled to avoid converting a whole
document to string for it to be ignored if you are
not using TRACE logging

Fixes #167