### PR TITLE
Adds base64Binary to ReflectUtil

### DIFF
--- a/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
@@ -126,6 +126,9 @@ public class ReflectUtil {
         else if ("Double".equals(type)) {
             field.set(object, new Double(value));
         }
+        else if ("base64Binary".equals(type)) {
+            field.set(object, DatatypeConverter.parseBase64Binary(value));
+        }
         else {
             throw new RuntimeException("Unexpected Type at setObjectField: " + field.getType().getCanonicalName() + field.getName());
         }

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -155,4 +155,11 @@ public class XmlGenDomTest {
         String[] strings = (String[]) xmlGenDom.fromXML("String[]", inputStream);
         assert strings.getClass().isArray();
     }
+
+    @Test
+    public void testFromXML_When_UpdateSet_Contains_Base64_Binary_No_Exception_Is_Thrown() throws Exception {
+        InputStream inputStream = new FileInputStream(new File("src/test/resources/xml/UpdateSetWithBase64Binary.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        UpdateSet updateSet = (UpdateSet) xmlGenDom.fromXML("UpdateSet", inputStream);
+    }
 }

--- a/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
+++ b/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
@@ -1,6 +1,7 @@
 package org.doublecloud.ws.util;
 
 import com.vmware.vim25.AboutInfo;
+import com.vmware.vim25.PropertyChange;
 import org.doublecloud.ws.util.testUtils.*;
 import org.junit.Assert;
 import org.junit.Test;
@@ -61,5 +62,16 @@ public class ReflectUtilTest {
         strings.add("string3");
         String[] stringArray = (String[]) ReflectUtil.parseToObject(type, strings);
         assert stringArray.getClass().isArray();
+    }
+
+    @Test
+    public void testReflectUtil_SetObjectField_Supports_Base64Binary_To_ByteArray() throws Exception {
+        String base64BinaryStr = "EtUGWJdr2BYg3Dom7G6oPAlHHcc=";
+        Object obj = new PropertyChange();
+        Field field = PropertyChange.class.getField("val");
+        String type = "base64Binary";
+        ReflectUtil.setObjectField(obj, field, type, base64BinaryStr);
+        PropertyChange pc = (PropertyChange) obj;
+        assert pc.getVal() instanceof byte[];
     }
 }

--- a/src/test/resources/xml/UpdateSetWithBase64Binary.xml
+++ b/src/test/resources/xml/UpdateSetWithBase64Binary.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <WaitForUpdatesExResponse xmlns="urn:vim25">
+            <returnval>
+                <version>3</version>
+                <filterSet>
+                    <filter type="PropertyFilter">session[5293e761-ee4a-d9cd-1dc3-8fe9c6ef7939]52379183-1a11-af2a-0e0a-c8ce4c507066</filter>
+                    <objectSet>
+                        <kind>modify</kind>
+                        <obj type="VirtualMachine">vm-13</obj>
+                        <changeSet>
+                            <name>config.annotation</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string"/>
+                        </changeSet>
+                        <changeSet>
+                            <name>config.changeVersion</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:string">2017-04-30T18:10:33.370382Z</val>
+                        </changeSet>
+                        <changeSet>
+                            <name>config.vmxConfigChecksum</name>
+                            <op>assign</op>
+                            <val xsi:type="xsd:base64Binary">EtUGWJdr2BYg3Dom7G6oPAlHHcc=</val>
+                        </changeSet>
+                    </objectSet>
+                </filterSet>
+            </returnval>
+        </WaitForUpdatesExResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Adds missing base64Binary to the ReflectUtil.
With it missing an update to an object that contained
a base64Binary field would cause a stack trace.

Fixes #179