### PR TITLE
#253 Add more details to XmlGenDom parsing error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: java
 sudo: false
 
 jdk:
-- oraclejdk7
 - oraclejdk8
 - openjdk7
+- openjdk8
 
 script:
 - gradle test

--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -88,7 +88,7 @@ class XmlGenDom extends XmlGen {
             Throwable throwThis = e.getNestedException() != null ? e.getNestedException() : e;
             throw new RemoteException("An error occurred parsing XML with return type: " + returnType, throwThis);
         } catch (Exception e1) {
-            throw new RemoteException("VI SDK invoke exception:" + e1);
+            throw new RemoteException("VI SDK invoke exception:" + e1, e1);
         }
         finally {
             if (is != null) {


### PR DESCRIPTION
Add non-DocumentException Exceptions as the cause for the constructed RemoteException in XmlGenDom.fromXML()