### PR TITLE
Let the SoapClient issue a log.trace only is TRACE is enabled

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -237,7 +237,9 @@ public abstract class SoapClient implements Client {
      */
     public String marshall(String methodName, Argument[] paras) {
         String soapMsg = XmlGen.toXML(methodName, paras, vimNameSpace);
-        log.trace("Marshalled Payload String xml: " + soapMsg);
+        if (log.isTraceEnabled()) {
+            log.trace("Marshalled Payload String xml: " + soapMsg);
+        }
         return soapMsg;
     }
 


### PR DESCRIPTION
In one of the applications where we are using yavijava library for interacting with the vCenter, we are noticing that every marshalling of the payload by the SoapClient, results in a call to log.trace with a huge marshalled payload, resulting in a performance impact. 

The commit here makes the log.trace (and thus the string concatenation) conditional, based on whether TRACE is enabled or not.
