### PR TITLE
Fix the cookie handler for ApacheHttpClient

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -204,7 +204,7 @@ public class ApacheHttpClient extends SoapClient {
 
             Header[] headers = response.getAllHeaders();
             for (Header header : headers) {
-                if (header.getName().equals("Set-Cookie")) {
+                if (header.getName().equalsIgnoreCase("Set-Cookie")) {
                     cookie = header.getValue();
                     break;
                 }


### PR DESCRIPTION
`Each header field consists of a case-insensitive field name ...`
https://www.rfc-editor.org/rfc/rfc7230#section-3.2