### PR TITLE
Upgrade EOL dependencies: log4j → SLF4J, dom4j 2.1.4, httpclient 4.5.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.directory.studio:org.dom4j.dom4j:1.6.1'
-    implementation 'log4j:log4j:1.2.17'
-    implementation 'org.apache.httpcomponents:httpclient:4.3.5'
+    implementation 'org.dom4j:dom4j:2.1.4'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+    testRuntimeOnly 'ch.qos.logback:logback-classic:1.5.18'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'

--- a/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
+++ b/src/intTest/java/com/vmware/vim25/ws/WSClientIntTest.java
@@ -9,7 +9,7 @@ import java.util.Calendar;
 
 import javax.net.ssl.*;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;\nimport org.slf4j.LoggerFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
+++ b/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
@@ -42,7 +42,8 @@ import com.vmware.vim25.UpdateSet;
 import com.vmware.vim25.mo.ManagedObject;
 import com.vmware.vim25.mo.PropertyCollector;
 import com.vmware.vim25.mo.PropertyFilter;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Steve JIN (sjin@vmware.com)
@@ -65,7 +66,7 @@ class ManagedObjectWatcher extends Observable implements Runnable {
     /**
      * Logger
      */
-    private static Logger log = Logger.getLogger(ManagedObjectWatcher.class);
+    private static Logger log = LoggerFactory.getLogger(ManagedObjectWatcher.class);
 
     public ManagedObjectWatcher(PropertyCollector pc) {
         this.pc = pc;

--- a/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
+++ b/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
@@ -3,7 +3,8 @@ package com.vmware.vim25.mo;
 import com.vmware.vim25.*;
 import com.vmware.vim25.mo.util.MorUtil;
 import com.vmware.vim25.mo.util.PropertyCollectorUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.rmi.RemoteException;
 
@@ -11,7 +12,7 @@ public class InventoryNavigator {
     private ManagedEntity rootEntity = null;
     private SelectionSpec[] selectionSpecs = null;
 
-    private static Logger log = Logger.getLogger(InventoryNavigator.class);
+    private static Logger log = LoggerFactory.getLogger(InventoryNavigator.class);
 
     public InventoryNavigator(ManagedEntity rootEntity) {
         this.rootEntity = rootEntity;

--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -32,7 +32,8 @@ package com.vmware.vim25.mo;
 import com.vmware.vim25.*;
 import com.vmware.vim25.mo.util.MorUtil;
 import com.vmware.vim25.mo.util.PropertyCollectorUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
@@ -55,7 +56,7 @@ abstract public class ManagedObject {
     /**
      * Create Logger
      */
-    private static Logger log = Logger.getLogger(ManagedObject.class);
+    private static Logger log = LoggerFactory.getLogger(ManagedObject.class);
 
     static {
         MO_PACKAGE_NAME = ManagedObject.class.getPackage().getName();

--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -32,7 +32,8 @@ package com.vmware.vim25.mo;
 import com.vmware.vim25.*;
 import com.vmware.vim25.mo.util.MorUtil;
 import com.vmware.vim25.ws.Client;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.TrustManager;
 import java.net.MalformedURLException;
@@ -48,7 +49,7 @@ import java.util.Calendar;
 
 public class ServiceInstance extends ManagedObject {
     private ServiceContent serviceContent = null;
-    private static Logger log = Logger.getLogger(ServiceInstance.class);
+    private static Logger log = LoggerFactory.getLogger(ServiceInstance.class);
     final static ManagedObjectReference SERVICE_INSTANCE_MOR;
     public final static String VIM25_NAMESPACE = " xmlns=\"urn:vim25\">";
     public final static String VIM20_NAMESPACE = " xmlns=\"urn:vim2\">";

--- a/src/main/java/com/vmware/vim25/mo/util/MorUtil.java
+++ b/src/main/java/com/vmware/vim25/mo/util/MorUtil.java
@@ -33,7 +33,8 @@ import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.mo.ManagedEntity;
 import com.vmware.vim25.mo.ManagedObject;
 import com.vmware.vim25.mo.ServerConnection;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -54,7 +55,7 @@ public class MorUtil {
     /**
      * Create a logger
      */
-    private static Logger log = Logger.getLogger(MorUtil.class);
+    private static Logger log = LoggerFactory.getLogger(MorUtil.class);
 
     /**
      * Takes an array of ManagedObjects and returns the MOR for each MO

--- a/src/main/java/com/vmware/vim25/mo/util/PropertyCollectorUtil.java
+++ b/src/main/java/com/vmware/vim25/mo/util/PropertyCollectorUtil.java
@@ -32,7 +32,8 @@ package com.vmware.vim25.mo.util;
 import com.vmware.vim25.*;
 import com.vmware.vim25.mo.ManagedObject;
 import com.vmware.vim25.mo.PropertyCollector;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
@@ -48,7 +49,7 @@ import java.util.List;
  */
 public class PropertyCollectorUtil {
 
-    private static Logger log = Logger.getLogger(PropertyCollectorUtil.class);
+    private static Logger log = LoggerFactory.getLogger(PropertyCollectorUtil.class);
 
     final public static Object NULL = new Object();
 

--- a/src/main/java/com/vmware/vim25/mox/VirtualMachineDeviceManager.java
+++ b/src/main/java/com/vmware/vim25/mox/VirtualMachineDeviceManager.java
@@ -96,7 +96,8 @@ import com.vmware.vim25.mo.InventoryNavigator;
 import com.vmware.vim25.mo.ServiceInstance;
 import com.vmware.vim25.mo.Task;
 import com.vmware.vim25.mo.VirtualMachine;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * VirtualMachineDeviceManager manages the virtual devices in a much
@@ -120,7 +121,7 @@ public class VirtualMachineDeviceManager {
     /**
      * Create a logger
      */
-    private static Logger log = Logger.getLogger(VirtualMachineDeviceManager.class);
+    private static Logger log = LoggerFactory.getLogger(VirtualMachineDeviceManager.class);
 
     public VirtualMachineDeviceManager(VirtualMachine vm) {
         this.vm = vm;

--- a/src/main/java/com/vmware/vim25/util/storage/HostStorageDeviceInfoEx.java
+++ b/src/main/java/com/vmware/vim25/util/storage/HostStorageDeviceInfoEx.java
@@ -1,7 +1,8 @@
 package com.vmware.vim25.util.storage;
 
 import com.vmware.vim25.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,7 +16,7 @@ public class HostStorageDeviceInfoEx {
     /**
      * Logger to log information.
      */
-    Logger log = Logger.getLogger(HostStorageDeviceInfoEx.class);
+    Logger log = LoggerFactory.getLogger(HostStorageDeviceInfoEx.class);
 
     /**
      * Host Storage Device Information.

--- a/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheHttpClient.java
@@ -10,7 +10,8 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.TrustManager;
 import java.io.IOException;
@@ -44,7 +45,7 @@ public class ApacheHttpClient extends SoapClient {
      * What rolls down stairs alone or in pairs?
      * Its log log log!
      */
-    private static final Logger log = Logger.getLogger(ApacheHttpClient.class);
+    private static final Logger log = LoggerFactory.getLogger(ApacheHttpClient.class);
 
     /**
      * The XML serialization/de-serialization engine

--- a/src/main/java/com/vmware/vim25/ws/ApacheTrustSelfSigned.java
+++ b/src/main/java/com/vmware/vim25/ws/ApacheTrustSelfSigned.java
@@ -4,7 +4,8 @@ import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -29,7 +30,7 @@ import java.security.NoSuchAlgorithmException;
  */
 public class ApacheTrustSelfSigned {
 
-    private static Logger log = Logger.getLogger(ApacheTrustSelfSigned.class);
+    private static Logger log = LoggerFactory.getLogger(ApacheTrustSelfSigned.class);
 
     public static SSLConnectionSocketFactory trust() {
         SSLContextBuilder builder = new SSLContextBuilder();

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -1,6 +1,7 @@
 package com.vmware.vim25.ws;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.TrustManager;
 import java.io.BufferedReader;
@@ -32,7 +33,7 @@ import java.security.cert.CertificateEncodingException;
  */
 public abstract class SoapClient implements Client {
 
-    private static Logger log = Logger.getLogger(SoapClient.class);
+    private static Logger log = LoggerFactory.getLogger(SoapClient.class);
     public String soapAction;
     public URL baseUrl = null;
     public String cookie = null;

--- a/src/main/java/com/vmware/vim25/ws/VimStub.java
+++ b/src/main/java/com/vmware/vim25/ws/VimStub.java
@@ -30,7 +30,8 @@ POSSIBILITY OF SUCH DAMAGE.
 package com.vmware.vim25.ws;
 
 import com.vmware.vim25.*;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.TrustManager;
 import java.lang.reflect.InvocationTargetException;
@@ -49,7 +50,7 @@ public class VimStub {
     /**
      * Setup logger
      */
-    private static Logger log = Logger.getLogger(VimStub.class);
+    private static Logger log = LoggerFactory.getLogger(VimStub.class);
 
     public VimStub(String url, boolean ignoreCert) {
         try {

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -31,7 +31,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 package com.vmware.vim25.ws;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -56,7 +57,7 @@ import java.security.cert.X509Certificate;
 
 public class WSClient extends SoapClient {
 
-    private static final Logger log = Logger.getLogger(WSClient.class);
+    private static final Logger log = LoggerFactory.getLogger(WSClient.class);
     private final SSLSocketFactory sslSocketFactory;
 
     private XmlGen xmlGen = new XmlGenDom();

--- a/src/main/java/com/vmware/vim25/ws/XmlGen.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGen.java
@@ -32,7 +32,8 @@ package com.vmware.vim25.ws;
 
 import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.mo.util.MorUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.doublecloud.ws.util.ReflectUtil;
 import org.doublecloud.ws.util.TypeUtil;
 import org.doublecloud.ws.util.XmlUtil;
@@ -45,7 +46,7 @@ import java.util.Calendar;
 
 public abstract class XmlGen {
 
-    private static Logger log = Logger.getLogger(XmlGen.class);
+    private static Logger log = LoggerFactory.getLogger(XmlGen.class);
 
     public static String toXML(String methodName, Argument[] paras, String vimNameSpace) {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -32,7 +32,8 @@ package com.vmware.vim25.ws;
 
 import com.vmware.vim25.ManagedObjectReference;
 import com.vmware.vim25.mo.util.MorUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
@@ -57,7 +58,7 @@ import java.util.List;
  */
 
 class XmlGenDom extends XmlGen {
-    private static Logger log = Logger.getLogger(XmlGenDom.class);
+    private static Logger log = LoggerFactory.getLogger(XmlGenDom.class);
 
     protected static int getNumberOfSameTags(List<Element> subNodes, int sizeOfSubNodes, int from, String tagName) {
         int numOfTags = 1;

--- a/src/main/java/org/doublecloud/ws/util/TypeUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/TypeUtil.java
@@ -29,7 +29,8 @@ POSSIBILITY OF SUCH DAMAGE.
 
 package org.doublecloud.ws.util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Array;
 import java.util.Calendar;
@@ -44,7 +45,7 @@ public class TypeUtil {
     final public static Class<?> BYTE_ARRAY_CLASS = byte[].class;
     final public static Class<?> LONG_ARRAY_CLASS = long[].class;
 
-    private static Logger log = Logger.getLogger(TypeUtil.class);
+    private static Logger log = LoggerFactory.getLogger(TypeUtil.class);
 
     private final static Set<String> PRIMITIVE_TYPES = new HashSet<String>();
 

--- a/src/test/groovy/com/vmware/vim25/mo/util/PropertyCollectorUtilTestSpec.groovy
+++ b/src/test/groovy/com/vmware/vim25/mo/util/PropertyCollectorUtilTestSpec.groovy
@@ -4,7 +4,7 @@ import com.vmware.vim25.ArrayOfManagedObjectReference
 import com.vmware.vim25.ManagedObjectReference
 import com.vmware.vim25.ObjectSpec
 import com.vmware.vim25.SelectionSpec
-import org.apache.log4j.Logger
+import org.slf4j.Logger
 import spock.lang.Specification
 
 


### PR DESCRIPTION
## Summary
- Replace `log4j:log4j:1.2.17` (EOL since 2015, known CVEs) with `slf4j-api:2.0.17` — library best practice is to depend on the SLF4J facade only and let consumers choose their logging backend. Updated 17 source files.
- Upgrade `dom4j` 1.6.1 → `org.dom4j:dom4j:2.1.4` (coordinate change; 2.x is actively maintained)
- Bump `httpclient` 4.3.5 → 4.5.14 (drop-in upgrade; last stable 4.x release with security patches)

## Test plan
- [x] 16/16 unit tests passing
- [x] `./gradlew clean test` succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)