### PR TITLE
Fix JUnit 4 not running; add DatatypeConverter test coverage; remove javax.xml.bind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
-    implementation 'javax.xml.bind:jaxb-api:2.3.1'
     testImplementation 'javax.servlet:javax.servlet-api:3.1.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.spockframework:spock-core:2.4-groovy-4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     testImplementation 'org.apache.groovy:groovy-all:4.0.24'
     testImplementation 'net.bytebuddy:byte-buddy:1.17.5'
     testRuntimeOnly 'org.objenesis:objenesis:3.3'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.13.0'
 }
 
 sourceSets {
@@ -72,6 +73,8 @@ task intTest(type: Test) {
 
 test {
     useJUnitPlatform()
+    // Needed for XmlGenDom to set detailMessage on JDK exception classes via reflection
+    jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
     testLogging {
         events 'started', 'passed', 'failed'
     }

--- a/src/main/java/com/vmware/vim25/ws/XmlGen.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGen.java
@@ -38,11 +38,13 @@ import org.doublecloud.ws.util.ReflectUtil;
 import org.doublecloud.ws.util.TypeUtil;
 import org.doublecloud.ws.util.XmlUtil;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 
 public abstract class XmlGen {
 
@@ -151,7 +153,15 @@ public abstract class XmlGen {
             sb.append("<").append(tagName).append(">").append(obj).append("</").append(tagName).append(">");
         }
         else if (obj instanceof Calendar) {
-            sb.append("<").append(tagName).append(" xsi:type=\"xsd:dateTime\">").append(DatatypeConverter.printDateTime((Calendar) obj)).append("</").append(tagName).append(">");
+            try {
+                Calendar cal = (Calendar) obj;
+                GregorianCalendar gcal = new GregorianCalendar(cal.getTimeZone());
+                gcal.setTimeInMillis(cal.getTimeInMillis());
+                String dateTimeStr = DatatypeFactory.newInstance().newXMLGregorianCalendar(gcal).toXMLFormat();
+                sb.append("<").append(tagName).append(" xsi:type=\"xsd:dateTime\">").append(dateTimeStr).append("</").append(tagName).append(">");
+            } catch (DatatypeConfigurationException e) {
+                throw new RuntimeException("Failed to serialize Calendar to xsd:dateTime", e);
+            }
         }
         else { // VIM type
             if (clazz == type) {

--- a/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
@@ -32,11 +32,12 @@ package org.doublecloud.ws.util;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.List;
-
-import javax.xml.bind.DatatypeConverter;
+import javax.xml.datatype.DatatypeFactory;
 
 public class ReflectUtil {
 
@@ -117,8 +118,12 @@ public class ReflectUtil {
             field.set(object, Boolean.valueOf(value));
         }
         else if ("Calendar".equals(type) || "dateTime".equals(type)) {
-            Calendar cal = DatatypeConverter.parseTime(value);
-            field.set(object, cal);
+            try {
+                Calendar cal = DatatypeFactory.newInstance().newXMLGregorianCalendar(value).toGregorianCalendar();
+                field.set(object, cal);
+            } catch (javax.xml.datatype.DatatypeConfigurationException e) {
+                throw new RuntimeException("Failed to parse dateTime: " + value, e);
+            }
         }
         else if ("double".equals(type)) {
             field.set(object, Double.parseDouble(value));
@@ -127,7 +132,7 @@ public class ReflectUtil {
             field.set(object, Double.valueOf(value));
         }
         else if ("base64Binary".equals(type)) {
-            field.set(object, DatatypeConverter.parseBase64Binary(value));
+            field.set(object, Base64.getDecoder().decode(value));
         }
         else {
             throw new RuntimeException("Unexpected Type at setObjectField: " + field.getType().getCanonicalName() + field.getName());
@@ -177,7 +182,7 @@ public class ReflectUtil {
             for (String s: values) {
                 tempStr += s;
             }
-            return DatatypeConverter.parseBase64Binary(tempStr);
+            return Base64.getDecoder().decode(tempStr);
         }
     }
 
@@ -273,7 +278,11 @@ public class ReflectUtil {
             return toBooleanArray(values);
         }
         else if ("Calendar".equals(type) || "dateTime".equals(type)) {
-            return DatatypeConverter.parseTime(values.get(0));
+            try {
+                return DatatypeFactory.newInstance().newXMLGregorianCalendar(values.get(0)).toGregorianCalendar();
+            } catch (javax.xml.datatype.DatatypeConfigurationException e) {
+                throw new RuntimeException("Failed to parse dateTime: " + values.get(0), e);
+            }
         }
         else if ("double".equals(type)) {
             return Double.valueOf(values.get(0));

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -75,7 +75,7 @@ public class XmlGenDomTest {
         ObjectContent objectContent = (ObjectContent) xmlGenDom.fromXML("ObjectContent", inputStream);
         DynamicProperty[] dps = objectContent.getPropSet();
         VirtualMachineConfigInfo configInfo = (VirtualMachineConfigInfo) dps[0].getVal();
-        byte[] exptected = javax.xml.bind.DatatypeConverter.parseBase64Binary("ox991LwhCGLf2gntXqKkSPdqC+A=");
+        byte[] exptected = java.util.Base64.getDecoder().decode("ox991LwhCGLf2gntXqKkSPdqC+A=");
         Assert.assertArrayEquals(configInfo.getVmxConfigChecksum(), exptected);
     }
 

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -7,9 +7,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.lang.reflect.ReflectPermission;
 import java.rmi.RemoteException;
-import java.security.AccessControlException;
 import java.util.Objects;
 
 public class XmlGenDomTest {
@@ -49,31 +47,10 @@ public class XmlGenDomTest {
     }
 
     @Test
-    public void set_Detail_Message_throws_Exception() throws Exception {
-        SecurityManager previous = System.getSecurityManager();
-        try {
-            SecurityManager securityManager = new SecurityManager() {
-                @Override
-                public void checkPermission(java.security.Permission perm) {
-                    if (perm instanceof ReflectPermission && "suppressAccessChecks".equals((perm.getName()))) {
-                        for (StackTraceElement elem : Thread.currentThread().getStackTrace()) {
-                            if ("com.vmware.vim25.ws.XmlGenDom".equals(elem.getClassName())) {
-                                throw new AccessControlException("Access Denied!");
-                            }
-                        }
-                    }
-                }
-            };
-            System.setSecurityManager(securityManager);
-
-            Throwable throwable = new Throwable("Illegal Access");
-            Throwable noMessage = (Throwable) XmlGenDom.setDetailMessageInException(throwable, "Error occured");
-            Assert.assertFalse(noMessage.getMessage().equals("Error occured"));
-        } catch (Exception e) {
-            throw e;
-        } finally {
-            System.setSecurityManager(previous);
-        }
+    public void set_Detail_Message_overwrites_existing_message() throws Exception {
+        Throwable throwable = new Throwable("original message");
+        Throwable result = (Throwable) XmlGenDom.setDetailMessageInException(throwable, "new message");
+        Assert.assertEquals("new message", result.getMessage());
     }
 
     @Test(expected = RemoteException.class)

--- a/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
@@ -1,0 +1,38 @@
+package com.vmware.vim25.ws;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.*;
+
+public class XmlGenTest {
+
+    @Test
+    public void toXML_serializes_Calendar_as_xsd_dateTime() {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cal.set(2015, Calendar.JUNE, 19, 15, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        Argument[] args = new Argument[]{new Argument("timestamp", "dateTime", cal)};
+        String xml = XmlGen.toXML("testMethod", args, " xmlns=\"urn:vim25\"");
+
+        assertTrue("XML should contain xsd:dateTime type", xml.contains("xsi:type=\"xsd:dateTime\""));
+        assertTrue("XML should contain timestamp tag", xml.contains("<timestamp"));
+        assertTrue("XML should contain closing timestamp tag", xml.contains("</timestamp>"));
+    }
+
+    @Test
+    public void toXML_serializes_Calendar_value_in_ISO8601_format() {
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cal.set(2015, Calendar.JUNE, 19, 15, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        Argument[] args = new Argument[]{new Argument("timestamp", "dateTime", cal)};
+        String xml = XmlGen.toXML("testMethod", args, " xmlns=\"urn:vim25\"");
+
+        // The serialized value must contain the date — format varies by impl but year/month/day must be present
+        assertTrue("XML should contain the date 2015-06-19", xml.contains("2015-06-19"));
+    }
+}

--- a/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
+++ b/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
@@ -1,16 +1,14 @@
 package org.doublecloud.ws.util;
 
-import com.vmware.vim25.AboutInfo;
 import com.vmware.vim25.PropertyChange;
 import org.doublecloud.ws.util.testUtils.*;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Calendar;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -42,36 +40,62 @@ public class ReflectUtilTest {
     }
 
     @Test
-    public void testToByteArray() throws Exception {
-        List<String> values = new ArrayList<String>();
-        char[] chars = "ox991LwhCGLf2gntXqKkSPdqC+A=".toCharArray();
-        for (char c: chars) {
+    public void testToByteArray_decodesBase64EncodedCharList() throws Exception {
+        String base64 = "ox991LwhCGLf2gntXqKkSPdqC+A=";
+        List<String> values = new ArrayList<>();
+        for (char c : base64.toCharArray()) {
             values.add(Character.toString(c));
         }
         byte[] actual = ReflectUtil.toByteArray(values);
-        byte[] expected = javax.xml.bind.DatatypeConverter.parseBase64Binary("ox991LwhCGLf2gntXqKkSPdqC+A=");
+        byte[] expected = Base64.getDecoder().decode(base64);
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void testReflectUtil_ParseToObject_Returns_String_Array() throws Exception {
-        String type = "String[]";
-        List<String> strings = new ArrayList<String>();
-        strings.add("string1");
-        strings.add("string2");
-        strings.add("string3");
-        String[] stringArray = (String[]) ReflectUtil.parseToObject(type, strings);
-        assert stringArray.getClass().isArray();
+        List<String> strings = Arrays.asList("string1", "string2", "string3");
+        String[] stringArray = (String[]) ReflectUtil.parseToObject("String[]", strings);
+        assertTrue(stringArray.getClass().isArray());
     }
 
     @Test
     public void testReflectUtil_SetObjectField_Supports_Base64Binary_To_ByteArray() throws Exception {
-        String base64BinaryStr = "EtUGWJdr2BYg3Dom7G6oPAlHHcc=";
         Object obj = new PropertyChange();
         Field field = PropertyChange.class.getField("val");
-        String type = "base64Binary";
-        ReflectUtil.setObjectField(obj, field, type, base64BinaryStr);
-        PropertyChange pc = (PropertyChange) obj;
-        assert pc.getVal() instanceof byte[];
+        ReflectUtil.setObjectField(obj, field, "base64Binary", "EtUGWJdr2BYg3Dom7G6oPAlHHcc=");
+        assertTrue(((PropertyChange) obj).getVal() instanceof byte[]);
+    }
+
+    @Test
+    public void testReflectUtil_SetObjectField_Supports_DateTime_To_Calendar() throws Exception {
+        Object obj = new PropertyChange();
+        Field field = PropertyChange.class.getField("val");
+        ReflectUtil.setObjectField(obj, field, "dateTime", "2015-06-19T10:00:00.000-05:00");
+        assertTrue(((PropertyChange) obj).getVal() instanceof Calendar);
+    }
+
+    @Test
+    public void testReflectUtil_SetObjectField_DateTime_Preserves_TimeInMillis() throws Exception {
+        Object obj = new PropertyChange();
+        Field field = PropertyChange.class.getField("val");
+        ReflectUtil.setObjectField(obj, field, "dateTime", "2015-06-19T10:00:00.000-05:00");
+        Calendar cal = (Calendar) ((PropertyChange) obj).getVal();
+        // 2015-06-19T10:00:00-05:00 == 2015-06-19T15:00:00Z
+        Calendar expected = Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"));
+        expected.set(2015, Calendar.JUNE, 19, 15, 0, 0);
+        expected.set(Calendar.MILLISECOND, 0);
+        assertEquals(expected.getTimeInMillis(), cal.getTimeInMillis());
+    }
+
+    @Test
+    public void testReflectUtil_ParseToObject_Returns_Calendar_For_Calendar_Type() throws Exception {
+        Object result = ReflectUtil.parseToObject("Calendar", Arrays.asList("2015-06-19T10:00:00.000-05:00"));
+        assertTrue(result instanceof Calendar);
+    }
+
+    @Test
+    public void testReflectUtil_ParseToObject_Returns_Calendar_For_dateTime_Alias() throws Exception {
+        Object result = ReflectUtil.parseToObject("dateTime", Arrays.asList("2015-06-19T10:00:00.000-05:00"));
+        assertTrue(result instanceof Calendar);
     }
 }


### PR DESCRIPTION
## Summary
- Fix JUnit 4 tests silently not running since step 3 added `useJUnitPlatform()` — added `junit-vintage-engine` so 90 JUnit 4 tests now execute
- Add `--add-opens java.base/java.lang=ALL-UNNAMED` JVM arg so `XmlGenDom` can set `detailMessage` on JDK exception classes via reflection (Java 9+ module fix)
- Add test coverage for all `DatatypeConverter` code paths before migration: `setObjectField`/`parseToObject` with `dateTime`/`Calendar`, `XmlGen` Calendar serialization
- Replace `javax.xml.bind:jaxb-api` (external shim) with built-in Java SE APIs: `javax.xml.datatype.DatatypeFactory` for date parsing/formatting, `java.util.Base64` for base64 — no external dependency needed
- Replace removed `SecurityManager`-based test in `XmlGenDomTest` with a direct behavior test

## Test plan
- [x] 106 tests passing (90 JUnit 4 tests now running that were previously skipped)
- [x] `./gradlew clean test` succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)