### PR TITLE
Replace deprecated Observable/Observer with typed PropertyFilterUpdateListener

### DIFF
--- a/src/main/java/com/vmware/vim/cf/CacheInstance.java
+++ b/src/main/java/com/vmware/vim/cf/CacheInstance.java
@@ -51,7 +51,7 @@ public class CacheInstance
 	  this.si = si;
 		mom = new ManagedObjectWatcher(si.getPropertyCollector());
 		cache = new ManagedObjectCache(si);
-		mom.addObserver(cache);
+		mom.addListener(cache);
 	}
 	
 	/**

--- a/src/main/java/com/vmware/vim/cf/ManagedObjectCache.java
+++ b/src/main/java/com/vmware/vim/cf/ManagedObjectCache.java
@@ -29,8 +29,6 @@ POSSIBILITY OF SUCH DAMAGE.
 
 package com.vmware.vim.cf;
 import java.util.Map;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.vmware.vim25.ManagedObjectReference;
@@ -47,7 +45,7 @@ import static com.vmware.vim.cf.NullObject.NULL;
  * @author Steve JIN (sjin@vmware.com)
  */
 
-class ManagedObjectCache implements Observer
+class ManagedObjectCache implements PropertyFilterUpdateListener
 {
     // each value is yet another child HashMap corresponding to a ManagedObject
     // The child HashMap has key -- property name; value -- property value
@@ -66,51 +64,46 @@ class ManagedObjectCache implements Observer
         return items;
     }
 
-    public void update(Observable obj, Object arg)
+    public void onUpdate(PropertyFilterUpdate[] pfus)
     {
-        if (arg instanceof PropertyFilterUpdate[])
+        for(int i=0; pfus!=null && i< pfus.length; i++)
         {
-            PropertyFilterUpdate[] pfus = (PropertyFilterUpdate[]) arg;
-            
-            for(int i=0; pfus!=null && i< pfus.length; i++)
+            ObjectUpdate[] ous = pfus[i].getObjectSet();
+            for(int j=0; ous!=null && j < ous.length; j++)
             {
-                ObjectUpdate[] ous = pfus[i].getObjectSet();
-                for(int j=0; ous!=null && j < ous.length; j++)
+                ManagedObjectReference mor = ous[j].getObj();
+                if(! items.containsKey(mor))
                 {
-                    ManagedObjectReference mor = ous[j].getObj();
-                    if(! items.containsKey(mor))
+                    items.put(mor, new ConcurrentHashMap<String, Object>());
+                }
+                Map<String, Object> moMap = items.get(mor);
+
+                PropertyChange[] pcs = ous[j].getChangeSet();
+                if(pcs==null)
+                {
+                  continue;
+                }
+                for(int k=0; k < pcs.length; k++)
+                {
+                    Object value = pcs[k].getVal();
+                    value = value == null ? NULL : value; //null is not allowed as value in CHM
+                    String propName = pcs[k].getName();
+                    if(moMap.containsKey(propName))
                     {
-                        items.put(mor, new ConcurrentHashMap<String, Object>());
+                        moMap.put(propName, value);
                     }
-                    Map<String, Object> moMap = items.get(mor);
-                    
-                    PropertyChange[] pcs = ous[j].getChangeSet();
-                    if(pcs==null)
+                    else
                     {
-                      continue;
-                    }
-                    for(int k=0; k < pcs.length; k++)
-                    {
-                    	  Object value = pcs[k].getVal();
-                    	  value = value == null ? NULL : value; //null is not allowed as value in CHM
-                    	  String propName = pcs[k].getName();
-                    	  if(moMap.containsKey(propName))
-                    	  {
-                    	    moMap.put(propName, value);
-                    	  }
-                    	  else
-                    	  {
-                    	    String parentPropName = getExistingParentPropName(moMap, propName);
-                    	    if(parentPropName != null)
-                    	    {
-                    	      ManagedObject mo = MorUtil.createExactManagedObject(si.getServerConnection(), mor);
-                    	      moMap.put(parentPropName, mo.getPropertyByPath(parentPropName));
-                    	    }
-                    	    else
-                    	    { //almost impossible to be here.
-                    	      moMap.put(propName, value);
-                    	    }
-                    	  }
+                        String parentPropName = getExistingParentPropName(moMap, propName);
+                        if(parentPropName != null)
+                        {
+                            ManagedObject mo = MorUtil.createExactManagedObject(si.getServerConnection(), mor);
+                            moMap.put(parentPropName, mo.getPropertyByPath(parentPropName));
+                        }
+                        else
+                        {
+                            moMap.put(propName, value);
+                        }
                     }
                 }
             }

--- a/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
+++ b/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
@@ -30,7 +30,8 @@ POSSIBILITY OF SUCH DAMAGE.
 package com.vmware.vim.cf;
 
 import java.rmi.RemoteException;
-import java.util.Observable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import com.vmware.vim25.NotAuthenticated;
@@ -49,27 +50,30 @@ import org.slf4j.LoggerFactory;
  * @author Steve JIN (sjin@vmware.com)
  */
 
-class ManagedObjectWatcher extends Observable implements Runnable {
+class ManagedObjectWatcher implements Runnable {
 
-    /**
-     * PropertyCollector
-     */
     private PropertyCollector pc;
-    /**
-     * Vector containing PropertyFilters
-     */
     private Vector<PropertyFilter> filters = new Vector<PropertyFilter>();
-    /**
-     * Version
-     */
     private String version = "";
-    /**
-     * Logger
-     */
     private static Logger log = LoggerFactory.getLogger(ManagedObjectWatcher.class);
+    private final List<PropertyFilterUpdateListener> listeners = new ArrayList<>();
 
     public ManagedObjectWatcher(PropertyCollector pc) {
         this.pc = pc;
+    }
+
+    public void addListener(PropertyFilterUpdateListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(PropertyFilterUpdateListener listener) {
+        listeners.remove(listener);
+    }
+
+    void notifyListeners(PropertyFilterUpdate[] updates) {
+        for (PropertyFilterUpdateListener listener : listeners) {
+            listener.onUpdate(updates);
+        }
     }
 
     /**
@@ -118,8 +122,7 @@ class ManagedObjectWatcher extends Observable implements Runnable {
             try {
                 UpdateSet update = pc.waitForUpdates(version);
                 PropertyFilterUpdate[] pfu = update.getFilterSet();
-                this.setChanged();
-                this.notifyObservers(pfu);
+                notifyListeners(pfu);
                 version = update.getVersion();
             }
             catch (NotAuthenticated na) {

--- a/src/main/java/com/vmware/vim/cf/PropertyFilterUpdateListener.java
+++ b/src/main/java/com/vmware/vim/cf/PropertyFilterUpdateListener.java
@@ -1,0 +1,8 @@
+package com.vmware.vim.cf;
+
+import com.vmware.vim25.PropertyFilterUpdate;
+
+@FunctionalInterface
+interface PropertyFilterUpdateListener {
+    void onUpdate(PropertyFilterUpdate[] updates);
+}

--- a/src/test/java/com/vmware/vim/cf/ManagedObjectCacheTest.java
+++ b/src/test/java/com/vmware/vim/cf/ManagedObjectCacheTest.java
@@ -1,0 +1,124 @@
+package com.vmware.vim.cf;
+
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.ObjectUpdate;
+import com.vmware.vim25.PropertyChange;
+import com.vmware.vim25.PropertyFilterUpdate;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ManagedObjectCacheTest {
+
+    @Test
+    public void isNotReadyBeforeAnyUpdate() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+        assertFalse(cache.isReady());
+    }
+
+    @Test
+    public void isReadyAfterEmptyUpdate() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+        cache.onUpdate(new PropertyFilterUpdate[0]);
+        assertTrue(cache.isReady());
+    }
+
+    @Test
+    public void onUpdate_storesNewPropertyInCache() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-123");
+        PropertyChange pc = propertyChange("name", "my-vm");
+        cache.onUpdate(updates(objectUpdate(mor, pc)));
+
+        assertEquals("my-vm", cache.getCachedItems().get(mor).get("name"));
+    }
+
+    @Test
+    public void onUpdate_updatesExistingPropertyInCache() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-123");
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("name", "original"))));
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("name", "updated"))));
+
+        assertEquals("updated", cache.getCachedItems().get(mor).get("name"));
+    }
+
+    @Test
+    public void onUpdate_storesNullValueAsNullObject() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-123");
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("name", null))));
+
+        assertSame(NullObject.NULL, cache.getCachedItems().get(mor).get("name"));
+    }
+
+    @Test
+    public void onUpdate_handlesNullChangeset_doesNotThrow() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-123");
+        ObjectUpdate ou = new ObjectUpdate();
+        ou.setObj(mor);
+        ou.setChangeSet(null);
+
+        PropertyFilterUpdate pfu = new PropertyFilterUpdate();
+        pfu.setObjectSet(new ObjectUpdate[]{ou});
+
+        cache.onUpdate(new PropertyFilterUpdate[]{pfu});
+        assertTrue(cache.isReady());
+    }
+
+    @Test
+    public void onUpdate_handlesNullObjectSet_doesNotThrow() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+        PropertyFilterUpdate pfu = new PropertyFilterUpdate();
+        pfu.setObjectSet(null);
+        cache.onUpdate(new PropertyFilterUpdate[]{pfu});
+        assertTrue(cache.isReady());
+    }
+
+    @Test
+    public void onUpdate_storesMultiplePropertiesForSameMor() {
+        ManagedObjectCache cache = new ManagedObjectCache(null);
+
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-123");
+        cache.onUpdate(updates(objectUpdate(mor,
+                propertyChange("name", "my-vm"),
+                propertyChange("powerState", "poweredOn"))));
+
+        assertEquals("my-vm", cache.getCachedItems().get(mor).get("name"));
+        assertEquals("poweredOn", cache.getCachedItems().get(mor).get("powerState"));
+    }
+
+    // --- helpers ---
+
+    private static ManagedObjectReference mor(String type, String val) {
+        ManagedObjectReference mor = new ManagedObjectReference();
+        mor.setType(type);
+        mor.setVal(val);
+        return mor;
+    }
+
+    private static PropertyChange propertyChange(String name, Object val) {
+        PropertyChange pc = new PropertyChange();
+        pc.setName(name);
+        pc.setVal(val);
+        return pc;
+    }
+
+    private static ObjectUpdate objectUpdate(ManagedObjectReference mor, PropertyChange... changes) {
+        ObjectUpdate ou = new ObjectUpdate();
+        ou.setObj(mor);
+        ou.setChangeSet(changes);
+        return ou;
+    }
+
+    private static PropertyFilterUpdate[] updates(ObjectUpdate... objectUpdates) {
+        PropertyFilterUpdate pfu = new PropertyFilterUpdate();
+        pfu.setObjectSet(objectUpdates);
+        return new PropertyFilterUpdate[]{pfu};
+    }
+}

--- a/src/test/java/com/vmware/vim/cf/ManagedObjectWatcherTest.java
+++ b/src/test/java/com/vmware/vim/cf/ManagedObjectWatcherTest.java
@@ -1,0 +1,57 @@
+package com.vmware.vim.cf;
+
+import com.vmware.vim25.PropertyFilterUpdate;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ManagedObjectWatcherTest {
+
+    @Test
+    public void addListener_registeredListenerIsNotifiedOnUpdate() {
+        // PropertyCollector is null — we won't call run(), just test listener wiring
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(null);
+
+        PropertyFilterUpdate[] sentUpdates = new PropertyFilterUpdate[]{new PropertyFilterUpdate()};
+        PropertyFilterUpdate[][] received = {null};
+
+        watcher.addListener(updates -> received[0] = updates);
+        watcher.notifyListeners(sentUpdates);
+
+        assertSame(sentUpdates, received[0]);
+    }
+
+    @Test
+    public void addListener_multipleListenersAllReceiveUpdates() {
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(null);
+
+        PropertyFilterUpdate[] sentUpdates = new PropertyFilterUpdate[0];
+        int[] callCount = {0};
+
+        watcher.addListener(updates -> callCount[0]++);
+        watcher.addListener(updates -> callCount[0]++);
+        watcher.notifyListeners(sentUpdates);
+
+        assertEquals(2, callCount[0]);
+    }
+
+    @Test
+    public void removeListener_removedListenerDoesNotReceiveUpdates() {
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(null);
+
+        int[] callCount = {0};
+        PropertyFilterUpdateListener listener = updates -> callCount[0]++;
+
+        watcher.addListener(listener);
+        watcher.removeListener(listener);
+        watcher.notifyListeners(new PropertyFilterUpdate[0]);
+
+        assertEquals(0, callCount[0]);
+    }
+
+    @Test
+    public void notifyListeners_withNoListeners_doesNotThrow() {
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(null);
+        watcher.notifyListeners(new PropertyFilterUpdate[0]); // should not throw
+    }
+}


### PR DESCRIPTION
## Summary

- Introduced `PropertyFilterUpdateListener` — a `@FunctionalInterface` with a typed `onUpdate(PropertyFilterUpdate[])` method
- Refactored `ManagedObjectWatcher` to drop `extends Observable`; added `addListener()`, `removeListener()`, `notifyListeners()` methods
- Refactored `ManagedObjectCache` to drop `implements Observer`; renamed `update(Observable, Object)` → `onUpdate(PropertyFilterUpdate[])`, eliminating the `instanceof` cast
- Updated `CacheInstance` to wire up via `mom.addListener(cache)` instead of `mom.addObserver(cache)`

## Test plan

- [ ] `ManagedObjectWatcherTest` — 4 tests covering add/remove listener and notify behavior
- [ ] `ManagedObjectCacheTest` — 8 tests covering ready state, property storage, null handling
- [ ] All existing tests still pass (no regressions)
- [ ] Tests written before production code per TDD

🤖 Generated with [Claude Code](https://claude.com/claude-code)