### PR TITLE
Add GitHub Actions CI to run tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ gradle, master ]
+  push:
+    branches: [ gradle, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Publish test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: build/reports/tests/test/


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — runs `./gradlew test` on every PR and push to `gradle` or `master`
- Uses JDK 21 Temurin (matches our `gradle-daemon-jvm.properties`)
- Uploads the Gradle HTML test report as an artifact on every run so failures are inspectable without re-running locally

## Test plan

- [ ] This PR itself should trigger the workflow and go green
- [ ] A future PR with a failing test should show a red check

🤖 Generated with [Claude Code](https://claude.com/claude-code)