### PR TITLE
Add unit tests for NullObject, DeepCopier, SoapAction

### DIFF
--- a/src/test/java/com/vmware/vim/cf/DeepCopierTest.java
+++ b/src/test/java/com/vmware/vim/cf/DeepCopierTest.java
@@ -1,0 +1,81 @@
+package com.vmware.vim.cf;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.*;
+
+public class DeepCopierTest {
+
+    // Test fixture: mutable class with public fields and no-arg constructor
+    public static class SimpleBean {
+        public String name;
+        public SimpleBean() {}
+    }
+
+    public static class BeanWithArray {
+        public SimpleBean[] items;
+        public BeanWithArray() {}
+    }
+
+    @Test
+    public void deepCopy_finalClass_returnsSameReference() throws Exception {
+        String original = "immutable";
+        assertSame(original, DeepCopier.deepCopy(original));
+    }
+
+    @Test
+    public void deepCopy_integer_returnsSameReference() throws Exception {
+        Integer original = 42;
+        assertSame(original, DeepCopier.deepCopy(original));
+    }
+
+    @Test
+    public void deepCopy_calendar_producesNewInstanceWithSameTimeMillis() throws Exception {
+        Calendar original = Calendar.getInstance();
+        original.setTimeInMillis(1_000_000_000L);
+
+        Calendar copy = (Calendar) DeepCopier.deepCopy(original);
+
+        assertNotSame(original, copy);
+        assertEquals(original.getTimeInMillis(), copy.getTimeInMillis());
+    }
+
+    @Test
+    public void deepCopy_mutableBean_producesNewInstance() throws Exception {
+        SimpleBean original = new SimpleBean();
+        original.name = "test";
+
+        SimpleBean copy = (SimpleBean) DeepCopier.deepCopy(original);
+
+        assertNotSame(original, copy);
+        assertEquals("test", copy.name);
+    }
+
+    @Test
+    public void deepCopy_mutableBean_withNullField_doesNotThrow() throws Exception {
+        SimpleBean original = new SimpleBean();
+        original.name = null;
+
+        SimpleBean copy = (SimpleBean) DeepCopier.deepCopy(original);
+
+        assertNotSame(original, copy);
+        assertNull(copy.name);
+    }
+
+    @Test
+    public void deepCopy_beanWithArray_copiesArrayItems() throws Exception {
+        SimpleBean item = new SimpleBean();
+        item.name = "item1";
+        BeanWithArray original = new BeanWithArray();
+        original.items = new SimpleBean[]{item};
+
+        BeanWithArray copy = (BeanWithArray) DeepCopier.deepCopy(original);
+
+        assertNotSame(original, copy);
+        assertNotSame(original.items, copy.items);
+        assertEquals(1, copy.items.length);
+        assertEquals("item1", copy.items[0].name);
+    }
+}

--- a/src/test/java/com/vmware/vim/cf/NullObjectTest.java
+++ b/src/test/java/com/vmware/vim/cf/NullObjectTest.java
@@ -1,0 +1,28 @@
+package com.vmware.vim.cf;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NullObjectTest {
+
+    @Test
+    public void NULL_isNotJavaNull() {
+        assertNotNull(NullObject.NULL);
+    }
+
+    @Test
+    public void NULL_isInstanceOfNullObject() {
+        assertTrue(NullObject.NULL instanceof NullObject);
+    }
+
+    @Test
+    public void NULL_isSingleton() {
+        assertSame(NullObject.NULL, NullObject.NULL);
+    }
+
+    @Test
+    public void toString_returnsLiteralNullString() {
+        assertEquals("null", NullObject.NULL.toString());
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/SoapActionTest.java
+++ b/src/test/java/com/vmware/vim25/ws/SoapActionTest.java
@@ -1,0 +1,43 @@
+package com.vmware.vim25.ws;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SoapActionTest {
+
+    @Test
+    public void soapActionHeader_toStringIsHeaderName() {
+        assertEquals("SOAPAction", SoapAction.SOAP_ACTION_HEADER.toString());
+    }
+
+    @Test
+    public void apiVersionValues_matchExpectedUrns() {
+        assertEquals("urn:vim25/4.0", SoapAction.SOAP_ACTION_V40.toString());
+        assertEquals("urn:vim25/4.1", SoapAction.SOAP_ACTION_V41.toString());
+        assertEquals("urn:vim25/5.0", SoapAction.SOAP_ACTION_V50.toString());
+        assertEquals("urn:vim25/5.1", SoapAction.SOAP_ACTION_V51.toString());
+        assertEquals("urn:vim25/5.5", SoapAction.SOAP_ACTION_V55.toString());
+        assertEquals("urn:vim25/6.0", SoapAction.SOAP_ACTION_V60.toString());
+    }
+
+    @Test
+    public void equalsName_returnsTrue_whenValueMatches() {
+        assertTrue(SoapAction.SOAP_ACTION_V60.equalsName("urn:vim25/6.0"));
+    }
+
+    @Test
+    public void equalsName_returnsFalse_whenValueDiffers() {
+        assertFalse(SoapAction.SOAP_ACTION_V60.equalsName("urn:vim25/5.5"));
+    }
+
+    @Test
+    public void equalsName_returnsFalse_whenNull() {
+        assertFalse(SoapAction.SOAP_ACTION_V60.equalsName(null));
+    }
+
+    @Test
+    public void allEnumConstants_arePresent() {
+        assertEquals(7, SoapAction.values().length);
+    }
+}


### PR DESCRIPTION
## Summary

Second coverage batch — 3 classes, 16 new tests.

- **`NullObjectTest`** — singleton identity (`assertSame`), `instanceof` check, `toString()` returns `"null"`
- **`DeepCopierTest`** — final classes return same reference, `Calendar` copies `timeInMillis`, mutable beans produce new instances, null fields skipped gracefully, arrays are deep-copied element-by-element
- **`SoapActionTest`** — all 6 API version URN values, header constant, `equalsName` match/mismatch/null, enum count guard

## Test plan

- [ ] All 16 new tests pass (CI will verify)
- [ ] No regressions in existing suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)