### PR TITLE
Add unit tests for SSL trust classes

### DIFF
--- a/src/test/java/com/vmware/vim25/ws/ApacheTrustSelfSignedTest.java
+++ b/src/test/java/com/vmware/vim25/ws/ApacheTrustSelfSignedTest.java
@@ -1,0 +1,24 @@
+package com.vmware.vim25.ws;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ApacheTrustSelfSignedTest {
+
+    @Test
+    public void trust_returnsNonNullSocketFactory() {
+        SSLConnectionSocketFactory factory = ApacheTrustSelfSigned.trust();
+        assertNotNull(factory);
+    }
+
+    @Test
+    public void trust_calledTwice_returnsNewInstanceEachTime() {
+        SSLConnectionSocketFactory first = ApacheTrustSelfSigned.trust();
+        SSLConnectionSocketFactory second = ApacheTrustSelfSigned.trust();
+        assertNotNull(first);
+        assertNotNull(second);
+        assertNotSame(first, second);
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/CustomSSLTrustContextCreatorTest.java
+++ b/src/test/java/com/vmware/vim25/ws/CustomSSLTrustContextCreatorTest.java
@@ -1,0 +1,62 @@
+package com.vmware.vim25.ws;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.lang.reflect.Field;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static org.junit.Assert.*;
+
+public class CustomSSLTrustContextCreatorTest {
+
+    private static final TrustManager NOOP_TRUST_MANAGER = new X509TrustManager() {
+        public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+        public void checkClientTrusted(X509Certificate[] c, String a) throws CertificateException {}
+        public void checkServerTrusted(X509Certificate[] c, String a) throws CertificateException {}
+    };
+
+    @After
+    public void resetState() throws Exception {
+        CustomSSLTrustContextCreator.setContextAlreadyCreated(false);
+        Field ctx = CustomSSLTrustContextCreator.class.getDeclaredField("sslContext");
+        ctx.setAccessible(true);
+        ctx.set(null, null);
+    }
+
+    @Test
+    public void getTrustContext_returnsNonNullSSLContext() throws Exception {
+        SSLContext context = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        assertNotNull(context);
+    }
+
+    @Test
+    public void getTrustContext_returnsTLSContext() throws Exception {
+        SSLContext context = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        assertEquals("TLS", context.getProtocol());
+    }
+
+    @Test
+    public void getTrustContext_calledTwice_returnsSameInstance() throws Exception {
+        SSLContext first = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        SSLContext second = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        assertSame(first, second);
+    }
+
+    @Test
+    public void setContextAlreadyCreated_false_allowsNewContext() throws Exception {
+        SSLContext first = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        CustomSSLTrustContextCreator.setContextAlreadyCreated(false);
+
+        Field ctx = CustomSSLTrustContextCreator.class.getDeclaredField("sslContext");
+        ctx.setAccessible(true);
+        ctx.set(null, null);
+
+        SSLContext second = CustomSSLTrustContextCreator.getTrustContext(NOOP_TRUST_MANAGER);
+        assertNotSame(first, second);
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/TrustAllSSLTest.java
+++ b/src/test/java/com/vmware/vim25/ws/TrustAllSSLTest.java
@@ -1,0 +1,47 @@
+package com.vmware.vim25.ws;
+
+import org.junit.After;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
+
+public class TrustAllSSLTest {
+
+    @After
+    public void resetStaticState() throws Exception {
+        Field created = TrustAllSSL.class.getDeclaredField("alreadyCreated");
+        created.setAccessible(true);
+        created.setBoolean(null, false);
+
+        Field ctx = TrustAllSSL.class.getDeclaredField("sslContext");
+        ctx.setAccessible(true);
+        ctx.set(null, null);
+    }
+
+    @Test
+    public void getTrustContext_returnsNonNullSSLContext() throws Exception {
+        SSLContext context = TrustAllSSL.getTrustContext();
+        assertNotNull(context);
+    }
+
+    @Test
+    public void getTrustContext_returnsTLSContext() throws Exception {
+        SSLContext context = TrustAllSSL.getTrustContext();
+        assertEquals("TLS", context.getProtocol());
+    }
+
+    @Test
+    public void getTrustContext_calledTwice_returnsSameInstance() throws Exception {
+        SSLContext first = TrustAllSSL.getTrustContext();
+        SSLContext second = TrustAllSSL.getTrustContext();
+        assertSame(first, second);
+    }
+
+    @Test
+    public void trustAllHttpsCertificates_doesNotThrow() throws Exception {
+        TrustAllSSL.trustAllHttpsCertificates();
+    }
+}


### PR DESCRIPTION
## Summary
- `TrustAllSSLTest` — 4 tests: non-null context, TLS protocol, singleton behavior, deprecated method
- `ApacheTrustSelfSignedTest` — 2 tests: non-null factory, new instance per call
- `CustomSSLTrustContextCreatorTest` — 4 tests: non-null context, TLS protocol, singleton, reset via `setContextAlreadyCreated`

Uses reflection to reset private static state in `TrustAllSSL` and `CustomSSLTrustContextCreator` between tests.

## Test plan
- [x] All 10 tests pass locally
- [x] CI will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)