### PR TITLE
Add unit tests for SoapClient and ApacheHttpClient

### DIFF
--- a/src/test/java/com/vmware/vim25/ws/ApacheHttpClientTest.java
+++ b/src/test/java/com/vmware/vim25/ws/ApacheHttpClientTest.java
@@ -1,0 +1,67 @@
+package com.vmware.vim25.ws;
+
+import org.junit.Test;
+
+import javax.net.ssl.X509TrustManager;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import static org.junit.Assert.*;
+
+public class ApacheHttpClientTest {
+
+    private static final X509TrustManager NOOP_TRUST_MANAGER = new X509TrustManager() {
+        public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+        public void checkClientTrusted(X509Certificate[] c, String a) throws CertificateException {}
+        public void checkServerTrusted(X509Certificate[] c, String a) throws CertificateException {}
+    };
+
+    @Test
+    public void constructor_stripsTrailingSlash() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com/", true);
+        assertEquals("http://vcenter.example.com", client.getBaseUrl().toString());
+    }
+
+    @Test
+    public void constructor_noTrailingSlash_urlUnchanged() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com", true);
+        assertEquals("http://vcenter.example.com", client.getBaseUrl().toString());
+    }
+
+    @Test
+    public void constructor_ignoreCertTrue_setsTrustAllSSL() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com", true);
+        Field f = ApacheHttpClient.class.getDeclaredField("trustAllSSL");
+        f.setAccessible(true);
+        assertTrue(f.getBoolean(client));
+    }
+
+    @Test
+    public void constructor_ignoreCertFalse_clearsTrustAllSSL() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com", false);
+        Field f = ApacheHttpClient.class.getDeclaredField("trustAllSSL");
+        f.setAccessible(true);
+        assertFalse(f.getBoolean(client));
+    }
+
+    @Test
+    public void oneArgConstructor_defaultsIgnoreCertToTrue() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com");
+        Field f = ApacheHttpClient.class.getDeclaredField("trustAllSSL");
+        f.setAccessible(true);
+        assertTrue(f.getBoolean(client));
+    }
+
+    @Test
+    public void constructor_withTrustManager_storesTrustManager() throws Exception {
+        ApacheHttpClient client = new ApacheHttpClient("http://vcenter.example.com", false, NOOP_TRUST_MANAGER);
+        assertSame(NOOP_TRUST_MANAGER, client.getTrustManager());
+    }
+
+    @Test(expected = MalformedURLException.class)
+    public void constructor_malformedUrl_throwsMalformedURLException() throws Exception {
+        new ApacheHttpClient("not-a-url", true);
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/SoapClientTest.java
+++ b/src/test/java/com/vmware/vim25/ws/SoapClientTest.java
@@ -1,0 +1,155 @@
+package com.vmware.vim25.ws;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.rmi.RemoteException;
+
+import static org.junit.Assert.*;
+
+public class SoapClientTest {
+
+    private StubSoapClient client;
+
+    private static class StubSoapClient extends SoapClient {
+        public Object invoke(String m, Argument[] p, String r) throws RemoteException { return null; }
+        public StringBuffer invokeAsString(String m, Argument[] p) throws RemoteException { return null; }
+    }
+
+    @Before
+    public void setUp() {
+        client = new StubSoapClient();
+    }
+
+    // --- setSoapActionOnApiVersion ---
+
+    @Test
+    public void setSoapAction_version40_setsV40Action() {
+        client.setSoapActionOnApiVersion("4.0");
+        assertEquals("urn:vim25/4.0", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_version41_setsV41Action() {
+        client.setSoapActionOnApiVersion("4.1");
+        assertEquals("urn:vim25/4.1", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_version50_setsV50Action() {
+        client.setSoapActionOnApiVersion("5.0");
+        assertEquals("urn:vim25/5.0", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_version51_setsV51Action() {
+        client.setSoapActionOnApiVersion("5.1");
+        assertEquals("urn:vim25/5.1", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_version55_setsV55Action() {
+        client.setSoapActionOnApiVersion("5.5");
+        assertEquals("urn:vim25/5.5", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_version60_setsV60Action() {
+        client.setSoapActionOnApiVersion("6.0");
+        assertEquals("urn:vim25/6.0", client.soapAction);
+    }
+
+    @Test
+    public void setSoapAction_unknownVersion_defaultsToV60() {
+        client.setSoapActionOnApiVersion("99.9");
+        assertEquals("urn:vim25/6.0", client.soapAction);
+    }
+
+    // --- hexify ---
+
+    @Test
+    public void hexify_emptyArray_returnsEmptyString() {
+        assertEquals("", SoapClient.hexify(new byte[]{}));
+    }
+
+    @Test
+    public void hexify_singleZeroByte_returnsTwoZeros() {
+        assertEquals("00", SoapClient.hexify(new byte[]{0x00}));
+    }
+
+    @Test
+    public void hexify_singleMaxByte_returnsFF() {
+        assertEquals("FF", SoapClient.hexify(new byte[]{(byte) 0xFF}));
+    }
+
+    @Test
+    public void hexify_multipleBytes_separatedByColon() {
+        assertEquals("0A:0B:0C", SoapClient.hexify(new byte[]{0x0A, 0x0B, 0x0C}));
+    }
+
+    // --- readStream ---
+
+    @Test
+    public void readStream_emptyStream_returnsEmptyBuffer() throws Exception {
+        InputStream is = new ByteArrayInputStream(new byte[0]);
+        assertEquals("", client.readStream(is).toString());
+    }
+
+    @Test
+    public void readStream_multiLineInput_joinsLines() throws Exception {
+        String input = "line1\nline2\nline3";
+        InputStream is = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+        assertEquals("line1line2line3", client.readStream(is).toString());
+    }
+
+    // --- marshall ---
+
+    @Test
+    public void marshall_returnsNonNullString() {
+        client.setVimNameSpace("urn:vim25/6.0");
+        String result = client.marshall("TestMethod", new Argument[0]);
+        assertNotNull(result);
+    }
+
+    @Test
+    public void marshall_containsMethodName() {
+        client.setVimNameSpace("urn:vim25/6.0");
+        String result = client.marshall("RetrieveServiceContent", new Argument[0]);
+        assertTrue(result.contains("RetrieveServiceContent"));
+    }
+
+    // --- getters/setters ---
+
+    @Test
+    public void cookie_roundTrip() {
+        client.setCookie("session=abc123");
+        assertEquals("session=abc123", client.getCookie());
+    }
+
+    @Test
+    public void vimNameSpace_roundTrip() {
+        client.setVimNameSpace("urn:vim25/6.0");
+        assertEquals("urn:vim25/6.0", client.getVimNameSpace());
+    }
+
+    @Test
+    public void connectTimeout_roundTrip() {
+        client.setConnectTimeout(5000);
+        assertEquals(5000, client.getConnectTimeout());
+    }
+
+    @Test
+    public void readTimeout_roundTrip() {
+        client.setReadTimeout(3000);
+        assertEquals(3000, client.getReadTimeout());
+    }
+
+    @Test
+    public void serverThumbprint_roundTrip() {
+        client.setServerThumbprint("AA:BB:CC");
+        assertEquals("AA:BB:CC", client.getServerThumbprint());
+    }
+}


### PR DESCRIPTION
## Summary
- `SoapClientTest` — 20 tests covering all pure logic in the abstract base class: `setSoapActionOnApiVersion` (7 version branches), `hexify` (4 cases), `readStream` (2), `marshall` (2), and all getters/setters (5). Uses a minimal `StubSoapClient` inner class — no network required.
- `ApacheHttpClientTest` — 7 tests covering constructor behavior: trailing slash stripping, `trustAllSSL` flag, default `ignoreCert=true`, `trustManager` storage, and `MalformedURLException` on bad URL.

## Test plan
- [x] All 27 tests pass locally
- [x] CI will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)