### PR TITLE
Fix infinite recursion in CacheInstance.getCopy(ManagedObjectReference)

### DIFF
--- a/src/main/java/com/vmware/vim/cf/CacheInstance.java
+++ b/src/main/java/com/vmware/vim/cf/CacheInstance.java
@@ -53,6 +53,11 @@ public class CacheInstance
 		cache = new ManagedObjectCache(si);
 		mom.addListener(cache);
 	}
+
+	CacheInstance(ManagedObjectCache cache)
+	{
+		this.cache = cache;
+	}
 	
 	/**
 	 * Add the managed objects and their properties to be watched.
@@ -105,7 +110,19 @@ public class CacheInstance
 	 */
   public Object getCopy(ManagedObjectReference mor, String propName)
   {
-    return getCopy(mor, propName);
+    Object obj = get(mor, propName);
+    if(obj == null)
+    {
+      return null;
+    }
+    try
+    {
+      obj = DeepCopier.deepCopy(obj);
+    } catch(Exception e)
+    {
+      throw new RuntimeException(e);
+    }
+    return obj;
   }
    
   /**

--- a/src/test/java/com/vmware/vim/cf/CacheInstanceTest.java
+++ b/src/test/java/com/vmware/vim/cf/CacheInstanceTest.java
@@ -1,0 +1,104 @@
+package com.vmware.vim.cf;
+
+import com.vmware.vim25.ManagedObjectReference;
+import com.vmware.vim25.ObjectUpdate;
+import com.vmware.vim25.PropertyChange;
+import com.vmware.vim25.PropertyFilterUpdate;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.*;
+
+public class CacheInstanceTest {
+
+    private ManagedObjectCache cache;
+    private CacheInstance cacheInstance;
+
+    @Before
+    public void setUp() {
+        cache = new ManagedObjectCache(null);
+        cacheInstance = new CacheInstance(cache);
+    }
+
+    @Test
+    public void getCopyByMor_returnsValueFromCache() {
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-1");
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("name", "my-vm"))));
+
+        Object result = cacheInstance.getCopy(mor, "name");
+
+        assertEquals("my-vm", result);
+    }
+
+    @Test
+    public void getCopyByMor_returnsDifferentInstance() {
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-1");
+        Calendar original = Calendar.getInstance();
+        original.setTimeInMillis(1_000_000_000L);
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("startTime", original))));
+
+        Object result = cacheInstance.getCopy(mor, "startTime");
+
+        assertNotSame(original, result);
+        assertEquals(original.getTimeInMillis(), ((Calendar) result).getTimeInMillis());
+    }
+
+    @Test
+    public void getCopyByMor_missingKey_returnsNull() {
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-1");
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("name", "my-vm"))));
+
+        assertNull(cacheInstance.getCopy(mor, "nonexistent"));
+    }
+
+    @Test
+    public void getCopyByMor_unknownMor_returnsNull() {
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-missing");
+
+        assertNull(cacheInstance.getCopy(mor, "name"));
+    }
+
+    @Test
+    public void getByMor_returnsValueFromCache() {
+        ManagedObjectReference mor = mor("VirtualMachine", "vm-1");
+        cache.onUpdate(updates(objectUpdate(mor, propertyChange("powerState", "poweredOn"))));
+
+        assertEquals("poweredOn", cacheInstance.get(mor, "powerState"));
+    }
+
+    @Test
+    public void getByMor_unknownMor_returnsNull() {
+        assertNull(cacheInstance.get(mor("VirtualMachine", "vm-missing"), "name"));
+    }
+
+    // --- helpers (mirrors ManagedObjectCacheTest) ---
+
+    private static ManagedObjectReference mor(String type, String val) {
+        ManagedObjectReference mor = new ManagedObjectReference();
+        mor.setType(type);
+        mor.setVal(val);
+        return mor;
+    }
+
+    private static PropertyChange propertyChange(String name, Object val) {
+        PropertyChange pc = new PropertyChange();
+        pc.setName(name);
+        pc.setVal(val);
+        return pc;
+    }
+
+    private static ObjectUpdate objectUpdate(ManagedObjectReference mor, PropertyChange... changes) {
+        ObjectUpdate ou = new ObjectUpdate();
+        ou.setObj(mor);
+        ou.setChangeSet(changes);
+        return ou;
+    }
+
+    private static PropertyFilterUpdate[] updates(ObjectUpdate... objectUpdates) {
+        PropertyFilterUpdate pfu = new PropertyFilterUpdate();
+        pfu.setObjectSet(objectUpdates);
+        return new PropertyFilterUpdate[]{pfu};
+    }
+}


### PR DESCRIPTION
## Bug

`CacheInstance.getCopy(ManagedObjectReference, String)` called itself recursively instead of delegating to `get()` + `DeepCopier.deepCopy()`, causing a `StackOverflowError` on every call.

```java
// Before (infinite recursion)
public Object getCopy(ManagedObjectReference mor, String propName) {
    return getCopy(mor, propName);
}

// After (correct)
public Object getCopy(ManagedObjectReference mor, String propName) {
    Object obj = get(mor, propName);
    if (obj == null) return null;
    try { return DeepCopier.deepCopy(obj); }
    catch (Exception e) { throw new RuntimeException(e); }
}
```

## Changes
- Fix recursive call to delegate to `get()` + `DeepCopier.deepCopy()` (mirrors the `ManagedObject` overload)
- Add null guard so missing MOR/property returns `null` instead of NPE
- Add package-private `CacheInstance(ManagedObjectCache)` constructor for testability
- 6 new tests in `CacheInstanceTest`

## Test plan
- [x] All 6 tests pass locally, including one that previously reproduced the `StackOverflowError`
- [x] CI will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)