### PR TITLE
Bump Java source/target compatibility to 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ group = "com.toastcoders"
 archivesBaseName = "yavijava"
 version = '6.5.01-SNAPSHOT'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-targetCompatibility = JavaVersion.VERSION_11
-sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_21
+sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- `sourceCompatibility` and `targetCompatibility`: `VERSION_11` → `VERSION_21`
- The Gradle daemon already runs Java 21 (`gradle-daemon-jvm.properties`); this aligns the compiler target with the runtime

## Test plan
- [x] All 204 tests pass locally
- [x] CI will run on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)