### PR TITLE
Fix Task sleep bug, fetchDVPortKeys ClassCast, and XXE vulnerability

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/Task.java
+++ b/src/main/java/com/vmware/vim25/mo/Task.java
@@ -196,7 +196,7 @@ public class Task extends ExtensibleManagedObject {
             if (tState.equals(TaskInfoState.running)) {
                 Thread.sleep(runningDelayInMillSecond);
             }
-            else {
+            else if (tState.equals(TaskInfoState.queued)) {
                 Thread.sleep(queuedDelayInMillSecond);
             }
         }

--- a/src/main/java/com/vmware/vim25/ws/VimStub.java
+++ b/src/main/java/com/vmware/vim25/ws/VimStub.java
@@ -580,7 +580,12 @@ public class VimStub {
         Argument[] paras = new Argument[2];
         paras[0] = new Argument("_this", "ManagedObjectReference", _this);
         paras[1] = new Argument("criteria", "DistributedVirtualSwitchPortCriteria", criteria);
-        return (String[]) getWsc().invoke("FetchDVPortKeys", paras, "String[]");
+        Object result = getWsc().invoke("FetchDVPortKeys", paras, "String[]");
+        if (result instanceof java.util.List) {
+            java.util.List<?> list = (java.util.List<?>) result;
+            return list.toArray(new String[0]);
+        }
+        return (String[]) result;
     }
 
     public DistributedVirtualPort[] fetchDVPorts(ManagedObjectReference _this, DistributedVirtualSwitchPortCriteria criteria) throws java.rmi.RemoteException, RuntimeFault {

--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -41,6 +41,8 @@ import org.dom4j.io.SAXReader;
 import org.doublecloud.ws.util.ReflectUtil;
 import org.doublecloud.ws.util.TypeUtil;
 
+import org.xml.sax.SAXException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Array;
@@ -78,6 +80,13 @@ class XmlGenDom extends XmlGen {
         Element root = null;
         try {
             SAXReader reader = new SAXReader();
+            try {
+                reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            } catch (SAXException e) {
+                throw new RemoteException("Failed to configure XML parser for XXE protection", e);
+            }
             Document doc = reader.read(is);
             if(log.isTraceEnabled()) {
                 log.trace("XML Document: " + doc.asXML());

--- a/src/test/java/com/vmware/vim25/mo/TaskTest.java
+++ b/src/test/java/com/vmware/vim25/mo/TaskTest.java
@@ -1,0 +1,54 @@
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.TaskInfo;
+import com.vmware.vim25.TaskInfoState;
+import org.junit.Test;
+
+import java.rmi.RemoteException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TaskTest {
+
+    private static Task taskReturning(TaskInfoState state) {
+        TaskInfo info = new TaskInfo();
+        info.setState(state);
+        return new Task(null, null) {
+            @Override
+            public TaskInfo getTaskInfo() throws RemoteException {
+                return info;
+            }
+        };
+    }
+
+    @Test
+    public void waitForTask_returnsSuccessString_whenTaskSucceeds() throws Exception {
+        Task task = taskReturning(TaskInfoState.success);
+        assertEquals("success", task.waitForTask(0, 0));
+    }
+
+    @Test
+    public void waitForTask_returnsErrorString_whenTaskFails() throws Exception {
+        Task task = taskReturning(TaskInfoState.error);
+        assertEquals("error", task.waitForTask(0, 0));
+    }
+
+    @Test
+    public void waitForTask_doesNotSleepAfterTaskSucceeds() throws Exception {
+        Task task = taskReturning(TaskInfoState.success);
+        long start = System.currentTimeMillis();
+        task.waitForTask(5000, 5000);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue("waitForTask slept after task completed; elapsed=" + elapsed + "ms", elapsed < 1000);
+    }
+
+    @Test
+    public void waitForTask_doesNotSleepAfterTaskFails() throws Exception {
+        Task task = taskReturning(TaskInfoState.error);
+        long start = System.currentTimeMillis();
+        task.waitForTask(5000, 5000);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue("waitForTask slept after task failed; elapsed=" + elapsed + "ms", elapsed < 1000);
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/VimStubFetchDVPortKeysTest.java
+++ b/src/test/java/com/vmware/vim25/ws/VimStubFetchDVPortKeysTest.java
@@ -1,0 +1,61 @@
+package com.vmware.vim25.ws;
+
+import com.vmware.vim25.ManagedObjectReference;
+import org.junit.Test;
+
+import javax.net.ssl.TrustManager;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class VimStubFetchDVPortKeysTest {
+
+    private static Client clientReturning(Object result) {
+        return new Client() {
+            public Object invoke(String m, Argument[] p, String r) { return result; }
+            public StringBuffer invokeAsString(String m, Argument[] p) { return null; }
+            public URL getBaseUrl() { return null; }
+            public void setBaseUrl(URL u) {}
+            public String getCookie() { return null; }
+            public void setCookie(String c) {}
+            public String getVimNameSpace() { return null; }
+            public void setVimNameSpace(String v) {}
+            public int getConnectTimeout() { return 0; }
+            public void setConnectTimeout(int t) {}
+            public int getReadTimeout() { return 0; }
+            public void setReadTimeout(int t) {}
+            public TrustManager getTrustManager() { return null; }
+            public void setSoapActionOnApiVersion(String v) {}
+            public String marshall(String m, Argument[] p) { return null; }
+            public Object unMarshall(String r, InputStream is) { return null; }
+            public StringBuffer readStream(InputStream s) throws IOException { return null; }
+        };
+    }
+
+    @Test
+    public void fetchDVPortKeys_whenServerReturnsStringArray_returnsStringArray() throws Exception {
+        VimStub stub = new VimStub(clientReturning(new String[]{"port-1", "port-2"}));
+        String[] result = stub.fetchDVPortKeys(new ManagedObjectReference(), null);
+        assertArrayEquals(new String[]{"port-1", "port-2"}, result);
+    }
+
+    @Test
+    public void fetchDVPortKeys_whenServerReturnsArrayList_returnsStringArray() throws Exception {
+        ArrayList<String> list = new ArrayList<>(Arrays.asList("port-1", "port-2"));
+        VimStub stub = new VimStub(clientReturning(list));
+        String[] result = stub.fetchDVPortKeys(new ManagedObjectReference(), null);
+        assertArrayEquals(new String[]{"port-1", "port-2"}, result);
+    }
+
+    @Test
+    public void fetchDVPortKeys_whenServerReturnsEmptyArrayList_returnsEmptyStringArray() throws Exception {
+        VimStub stub = new VimStub(clientReturning(new ArrayList<String>()));
+        String[] result = stub.fetchDVPortKeys(new ManagedObjectReference(), null);
+        assertArrayEquals(new String[0], result);
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -4,9 +4,11 @@ import com.vmware.vim25.*;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.rmi.RemoteException;
 import java.util.Objects;
 
@@ -138,5 +140,30 @@ public class XmlGenDomTest {
         InputStream inputStream = new FileInputStream(new File("src/test/resources/xml/UpdateSetWithBase64Binary.xml"));
         XmlGenDom xmlGenDom = new XmlGenDom();
         UpdateSet updateSet = (UpdateSet) xmlGenDom.fromXML("UpdateSet", inputStream);
+    }
+
+    @Test(expected = RemoteException.class)
+    public void fromXML_withDoctypeDeclaration_throwsRemoteException() throws Exception {
+        // DOCTYPE declarations must be rejected to prevent XXE attacks and offline
+        // DTD-fetch failures (issues #293, #240).
+        String payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<!DOCTYPE foo>\n" +
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+            "  <soapenv:Body><foo/></soapenv:Body>\n" +
+            "</soapenv:Envelope>";
+        InputStream is = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+        new XmlGenDom().fromXML("String", is);
+    }
+
+    @Test(expected = RemoteException.class)
+    public void fromXML_withExternalEntityReference_throwsRemoteException() throws Exception {
+        // External entity injection must be blocked (issue #293).
+        String payload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>\n" +
+            "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+            "  <soapenv:Body><foo>&xxe;</foo></soapenv:Body>\n" +
+            "</soapenv:Envelope>";
+        InputStream is = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
+        new XmlGenDom().fromXML("String", is);
     }
 }


### PR DESCRIPTION
## Summary

- **#275** — `Task.waitForTask` was sleeping unnecessarily after a task reached `success` or `error` state. The `else` branch of the sleep logic ran for any non-`running` state, including terminal states. Fixed to only sleep while `running` or `queued`.
- **#269** — `VimStub.fetchDVPortKeys` threw `ClassCastException` when the server returned an `ArrayList` instead of `String[]`. Fixed to detect and convert `List` results via `toArray()`.
- **#293 / #240** — `XmlGenDom` created a `SAXReader` with no XXE protection, allowing external entity injection and causing failures in offline environments. Fixed by setting three SAXReader features: `disallow-doctype-decl=true`, `external-general-entities=false`, `external-parameter-entities=false`.

All three fixes were written test-first (TDD): tests were confirmed failing RED before any production code was changed.

## Test plan

- [ ] `TaskTest` — verifies `waitForTask` returns correct state string and does not sleep after task completes
- [ ] `VimStubFetchDVPortKeysTest` — verifies `fetchDVPortKeys` handles both `String[]` and `ArrayList` returns without exception
- [ ] `XmlGenDomTest` — two new tests verify that DOCTYPE declarations and external entity references are rejected with `RemoteException`; all existing XML parsing tests continue to pass

Closes #275
Closes #269
Closes #293
Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)