### PR TITLE
Add missing ArrayOf wrappers and VirtualMachine.terminate()

### DIFF
--- a/src/main/java/com/vmware/vim25/ArrayOfDVSOpaqueCommandResultInfo.java
+++ b/src/main/java/com/vmware/vim25/ArrayOfDVSOpaqueCommandResultInfo.java
@@ -1,0 +1,17 @@
+package com.vmware.vim25;
+
+public class ArrayOfDVSOpaqueCommandResultInfo {
+    public DVSOpaqueCommandResultInfo[] DVSOpaqueCommandResultInfo;
+
+    public DVSOpaqueCommandResultInfo[] getDVSOpaqueCommandResultInfo() {
+        return this.DVSOpaqueCommandResultInfo;
+    }
+
+    public DVSOpaqueCommandResultInfo getDVSOpaqueCommandResultInfo(int i) {
+        return this.DVSOpaqueCommandResultInfo[i];
+    }
+
+    public void setDVSOpaqueCommandResultInfo(DVSOpaqueCommandResultInfo[] DVSOpaqueCommandResultInfo) {
+        this.DVSOpaqueCommandResultInfo = DVSOpaqueCommandResultInfo;
+    }
+}

--- a/src/main/java/com/vmware/vim25/ArrayOfHostDatastoreSystemDatastoreResult.java
+++ b/src/main/java/com/vmware/vim25/ArrayOfHostDatastoreSystemDatastoreResult.java
@@ -1,0 +1,17 @@
+package com.vmware.vim25;
+
+public class ArrayOfHostDatastoreSystemDatastoreResult {
+    public HostDatastoreSystemDatastoreResult[] HostDatastoreSystemDatastoreResult;
+
+    public HostDatastoreSystemDatastoreResult[] getHostDatastoreSystemDatastoreResult() {
+        return this.HostDatastoreSystemDatastoreResult;
+    }
+
+    public HostDatastoreSystemDatastoreResult getHostDatastoreSystemDatastoreResult(int i) {
+        return this.HostDatastoreSystemDatastoreResult[i];
+    }
+
+    public void setHostDatastoreSystemDatastoreResult(HostDatastoreSystemDatastoreResult[] HostDatastoreSystemDatastoreResult) {
+        this.HostDatastoreSystemDatastoreResult = HostDatastoreSystemDatastoreResult;
+    }
+}

--- a/src/main/java/com/vmware/vim25/DVSOpaqueCommandResultInfo.java
+++ b/src/main/java/com/vmware/vim25/DVSOpaqueCommandResultInfo.java
@@ -1,0 +1,12 @@
+package com.vmware.vim25;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @since SDK5.5
+ */
+public class DVSOpaqueCommandResultInfo extends DynamicData {
+    @Getter @Setter public ManagedObjectReference obj;
+    @Getter @Setter public MethodFault fault;
+}

--- a/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
+++ b/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
@@ -522,6 +522,13 @@ public class VirtualMachine extends ManagedEntity {
     }
 
     /**
+     * @since SDK5.5
+     */
+    public void terminate() throws InvalidState, TaskInProgress, RuntimeFault, RemoteException {
+        getVimService().terminateVM(getMOR());
+    }
+
+    /**
      * @since SDK4.0
      */
     public Task terminateFaultTolerantVM_Task(VirtualMachine vm) throws TaskInProgress, VmFaultToleranceIssue, InvalidState, RuntimeFault, RemoteException {


### PR DESCRIPTION
## Summary

- **#265** — Added `DVSOpaqueCommandResultInfo` and `ArrayOfDVSOpaqueCommandResultInfo`. The `ArrayOf*` wrapper was completely absent, causing `ClassNotFoundException` when any task response contained this type during XML deserialization. The base data class was also missing and has been added as a minimal stub extending `DynamicData`.
- **#225** — Added `ArrayOfHostDatastoreSystemDatastoreResult`. The base class `HostDatastoreSystemDatastoreResult` already existed; only the `ArrayOf*` wrapper needed was missing, causing `ClassNotFoundException` when calling `task.waitForTask()` after `removeDatastoreEx_Task`.
- **#244** — Added `VirtualMachine.terminate()` delegating to `VimStub.terminateVM()`, which already existed. The method was present in the vSphere API docs and VimStub but missing from the managed object class.

No TDD for these — they are declarations and delegation stubs with no logic to verify. Full test suite passes.

Closes #265
Closes #225
Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)