### PR TITLE
Throw on missingSet fault instead of silently returning null

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -170,6 +170,11 @@ abstract public class ManagedObject {
         Object propertyValue = null;
 
         if (objContent != null) {
+            MissingProperty[] missing = objContent.getMissingSet();
+            if (missing != null && missing.length > 0 && missing[0].getFault() != null) {
+                throw new RuntimeException(missing[0].getFault().getFault());
+            }
+
             DynamicProperty[] dynaProps = objContent.getPropSet();
 
             if ((dynaProps != null) && (dynaProps[0] != null)) {

--- a/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
@@ -1,0 +1,83 @@
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ManagedObjectCurrentPropertyTest {
+
+    // Subclass that bypasses the server call so we can inject any ObjectContent
+    static class TestManagedObject extends ManagedObject {
+        private final ObjectContent content;
+
+        TestManagedObject(ObjectContent content) {
+            this.content = content;
+        }
+
+        @Override
+        protected ObjectContent retrieveObjectProperties(String[] properties) {
+            return content;
+        }
+
+        public Object testGetCurrentProperty(String name) {
+            return getCurrentProperty(name);
+        }
+    }
+
+    @Test
+    public void getCurrentProperty_returnsNullWhenObjectContentIsNull() {
+        TestManagedObject mo = new TestManagedObject(null);
+        assertNull(mo.testGetCurrentProperty("name"));
+    }
+
+    @Test
+    public void getCurrentProperty_returnsNullWhenPropSetIsNull() {
+        TestManagedObject mo = new TestManagedObject(new ObjectContent());
+        assertNull(mo.testGetCurrentProperty("name"));
+    }
+
+    @Test
+    public void getCurrentProperty_throwsWhenMissingSetContainsFault() {
+        MissingProperty missing = new MissingProperty();
+        missing.setPath("host");
+        LocalizedMethodFault lmf = new LocalizedMethodFault();
+        lmf.setFault(new NotAuthenticated());
+        missing.setFault(lmf);
+
+        ObjectContent objContent = new ObjectContent();
+        objContent.setMissingSet(new MissingProperty[]{missing});
+
+        TestManagedObject mo = new TestManagedObject(objContent);
+
+        try {
+            mo.testGetCurrentProperty("host");
+            fail("Expected RuntimeException wrapping the server fault");
+        } catch (RuntimeException e) {
+            assertTrue("cause should be the MethodFault from missingSet",
+                e.getCause() instanceof NotAuthenticated);
+        }
+    }
+
+    @Test
+    public void getCurrentProperty_throwsWithFaultMessageWhenMissingSetHasLocalizedMessage() {
+        MissingProperty missing = new MissingProperty();
+        missing.setPath("config");
+        LocalizedMethodFault lmf = new LocalizedMethodFault();
+        lmf.setFault(new NotAuthenticated());
+        lmf.setLocalizedMessage("Not authenticated");
+        missing.setFault(lmf);
+
+        ObjectContent objContent = new ObjectContent();
+        objContent.setMissingSet(new MissingProperty[]{missing});
+
+        TestManagedObject mo = new TestManagedObject(objContent);
+
+        try {
+            mo.testGetCurrentProperty("config");
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            assertNotNull(e.getCause());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**#297** — When a vCenter SOAP response contains a `<missingSet>` element (e.g. a property retrieval fails because the session has expired and vCenter returns `NotAuthenticated`), `getCurrentProperty()` was ignoring the fault entirely and returning `null`. Callers had no way to distinguish a legitimately null property from a server-side fault.

The fix checks `missingSet` before `propSet` in `getCurrentProperty()` and throws a `RuntimeException` wrapping the `MethodFault` from the first missing entry. This preserves the existing method signature (no new checked exceptions) while giving callers a meaningful exception with the actual server fault as the cause.

`RuntimeException` is used rather than adding `throws RemoteException` to `getCurrentProperty` because that signature is implemented by dozens of getter methods across all managed object classes — changing it would be a large breaking API change.

## Test plan

- [ ] `ManagedObjectCurrentPropertyTest.getCurrentProperty_throwsWhenMissingSetContainsFault` — returns `NotAuthenticated` as the `RuntimeException` cause instead of null
- [ ] `ManagedObjectCurrentPropertyTest.getCurrentProperty_throwsWithFaultMessageWhenMissingSetHasLocalizedMessage` — same with a localized message attached
- [ ] Existing null cases (`null` object content, null `propSet`) continue to return null — verified by two passing baseline tests
- [ ] Full test suite passes with no regressions

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)