### PR TITLE
Update README to reflect current state of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,89 +1,94 @@
-[![Build Status](https://travis-ci.org/yavijava/yavijava.svg?branch=gradle)](https://travis-ci.org/yavijava/yavijava)
-[![Join the chat at https://gitter.im/yavijava/yavijava](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yavijava/yavijava?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![CI](https://github.com/yavijava/yavijava/actions/workflows/ci.yml/badge.svg?branch=gradle)](https://github.com/yavijava/yavijava/actions/workflows/ci.yml)
 
 Welcome to the YAVI Java API
 
 ## WHAT IS YAVI JAVA API?
 It is a fork of the VI Java API which is a set of Java libraries that aim to ease the usage of VI 
-SDK Web Services interfaces. It's now open-sourced under a mixed BSD license and Apache-2.0 license.
+SDK Web Services interfaces. It's open-sourced under a mixed BSD license and Apache-2.0 license.
 
-It provides the following benefits to the Java developers:
+It provides the following benefits to Java developers:
 * Enables OO programming with a well defined managed object model
-* Reduces the need to use ManagedObjectReference and makes possible 
-  compile time type checking
+* Reduces the need to use ManagedObjectReference and enables compile time type checking
 * Hides the complexity of the PropertyCollector
-* Provides necessary utility classes to simplify VI SDK web interfaces
-* High performance with 4+ times faster than AXIS engine
-* Adds the ability to provide your own HTTP Client
-* Adds logging using log4j
-* Adds gradle support for the build system
+* Provides utility classes to simplify VI SDK web interfaces
+* High performance — 4+ times faster than AXIS engine
+* Supports pluggable HTTP clients
+* Logging via SLF4J (bring your own implementation — Logback, Log4j 2, etc.)
+* Gradle-based build system
+* vSphere 6.5 API support (data objects, CryptoManager, SOAP action 6.5)
 
-As a result, the application code using this API is much shorter (70% less) 
-and much more readable than the equivalent using web service interfaces 
-directly. The API itself is straight-forward and easy to learn and use. 
+As a result, application code using this API is much shorter (70% less) and much more readable 
+than the equivalent using web service interfaces directly.
 
 ## WHO CREATED THE API?
 To find out more about the original VI Java API see http://vijava.sf.net
 
-As for who created this fork called YAVI Java that is Michael Rice.
-
+This fork (YAVI Java) was created by [Michael Rice](https://github.com/michaelrice).
 
 ## Whats with the name?
 
-The name YAVI means simply Yet Another VI Java. I forked this project and moved it to 
-github because the project seemd stale and I felt it needed new life. I wanted things 
-like GitHub, custom http clients, and logging, and tests as well as other stuff so I decided to 
-fork the project and do it.
-
+YAVI means simply Yet Another VI Java. I forked this project and moved it to GitHub because 
+the project seemed stale and needed new life — GitHub, custom HTTP clients, logging, tests, 
+and more.
 
 ## Do I have to change my code to use this?
 
-No!! This is a drop in replacement and requires no code modification, but does introduce some new
-dependencies (Always check the build.gradle for the latest requirements):
+No. This is a drop-in replacement requiring no code changes, but check UPDATES.md for 
+dependency-level breaking changes when upgrading versions.
 
-    dependencies {
-        compile 'org.apache.directory.studio:org.dom4j.dom4j:1.6.1'
-        compile 'log4j:log4j:1.2.17'
-        compile 'org.apache.httpcomponents:httpclient:4.3.5'
-        testCompile 'org.mockito:mockito-all:1.9.5'
-        testCompile group: 'junit', name: 'junit', version: '4.+'
-    }
+Current dependencies (always check `build.gradle` for the latest):
+
+```groovy
+dependencies {
+    implementation 'org.dom4j:dom4j:2.1.4'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
+}
+```
+
+> **Note:** SLF4J requires a logging implementation at runtime. Add one to your project,
+> for example `ch.qos.logback:logback-classic` or `org.slf4j:slf4j-simple`.
+
+> **Note:** HttpClient 5 (`httpclient5`) is a breaking upgrade from HttpClient 4. If your
+> application also uses HttpClient directly, see UPDATES.md for migration guidance.
+
+## Java Requirements
+
+| Action | Minimum JDK |
+|--------|------------|
+| Use the compiled jar | Java 11 |
+| Build from source | Java 21 |
 
 ## WHERE CAN I GET HELP?
 File a bug: https://github.com/yavijava/yavijava/issues
 
-IRC: Freenode IRC #vijava 
+## COPYRIGHT & LICENSE
+BSD. See the License.txt file for details.
 
-COPYRIGHT & LICENSE:
-BSD. See the License.txt file for details
+## What happened to the samples?
 
-
-## What happened to the samples?!?!
-
-Never fear. I removed them from the core of the project and made them their own project. They can be found here: https://github.com/yavijava/yavijava-samples
-
+They were removed from the core project and are maintained separately:
+https://github.com/yavijava/yavijava-samples
 
 ## Testing
 
-Testing is broken into two main packages which are discussed below. It is very important that pull requests you send include a test. 
-Many very large enterprise customers depend on this library so extensive work is being put into trying to cover as much of the codebase 
-as possible with tests.
-
-### Integration
-
-The first package is integration tests which are stored in src/intTest There is a properties file included that contains the URL, 
-username and password for use in connecting to a vCenter or HostSystem. It has a  default value of https://vcsa/sdk for its URL, 
-and 'administrator@vsphere.local' for the user name, and 'password' is used for the default password. The reason these defaults 
-are included is because I use the vCenter Server Appliance in SIM mode to do as many of the tests as possible and I create an 
-alias in my /etc/hosts file so vcsa always points at my local vCenter. Next I use a very basic shell script to configure the VCSA 
-SIM and use 'password' for my default password. To run these tests make sure the properties file contains valid information for your
-environment. Next from the project root where the build.gradle is execute ```gradle intTest``` or use the gradlew script and execute: 
-```./gradlew intTest```
+Testing is split into two packages. Pull requests that fix bugs or add functionality 
+must include tests.
 
 ### Unit
 
-The Second package is the unit tests. These tests are stored in src/test These are basic unit tests and should be created using either
-junit or spock. Tests can be written in pure Java or Groovy. Please use the appropriate folder for the language you create your test with. 
-The unit tests are run automatically by travis-ci when a pull request is opened, and they should always be run before you open a pull request 
-where you are introducing changes that either fix bugs, or add functionality to ensure they continue to pass with your changes. To run these 
-tests execute ```gradle test``` or use the gradlew script and execute ```./gradlew test```
+Unit tests live in `src/test`. Tests can be written in Java or Groovy (JUnit or Spock).
+They run automatically in CI on every pull request.
+
+```bash
+./gradlew test
+```
+
+### Integration
+
+Integration tests live in `src/intTest` and require a live vCenter or HostSystem.
+Edit the properties file in that directory with your environment's URL, username, and password.
+
+```bash
+./gradlew intTest
+```


### PR DESCRIPTION
## Summary

Brings the README up to date with the current state of the codebase:

- **CI badge**: Travis CI → GitHub Actions
- **Gitter badge**: removed (service shut down in 2022)
- **Logging**: log4j references replaced with SLF4J; note added about supplying a runtime implementation
- **Dependencies**: updated to current versions with modern Gradle DSL (`implementation`/`testImplementation`); correct group IDs and versions for dom4j 2.1.4, SLF4J 2.0.17, HttpClient 5
- **HttpClient 5**: breaking upgrade noted with pointer to UPDATES.md
- **Java requirements**: table added — Java 11 to run, Java 21 to build from source
- **vSphere 6.5**: added to feature list
- **IRC/Freenode**: removed (shut down in 2021)
- **Attribution**: Michael Rice's GitHub profile linked
- **Build commands**: standardised to `./gradlew` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)