### PR TITLE
fix(reflect): add double[] support to setObjectArrayField

### DIFF
--- a/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
+++ b/src/main/java/org/doublecloud/ws/util/ReflectUtil.java
@@ -162,6 +162,9 @@ public class ReflectUtil {
         else if ("boolean[]".equals(type)) {
             field.set(object, toBooleanArray(values));
         }
+        else if ("double[]".equals(type)) {
+            field.set(object, toDoubleArray(values));
+        }
         else {
             throw new RuntimeException("Unexpected Type at setObjectArrayField: " + field.getType().getCanonicalName() + field.getName());
         }

--- a/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
+++ b/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
@@ -1,6 +1,7 @@
 package org.doublecloud.ws.util;
 
 import com.vmware.vim25.PropertyChange;
+import com.vmware.vim25.StoragePerformanceSummary;
 import org.doublecloud.ws.util.testUtils.*;
 import org.junit.Test;
 
@@ -97,5 +98,29 @@ public class ReflectUtilTest {
     public void testReflectUtil_ParseToObject_Returns_Calendar_For_dateTime_Alias() throws Exception {
         Object result = ReflectUtil.parseToObject("dateTime", Arrays.asList("2015-06-19T10:00:00.000-05:00"));
         assertTrue(result instanceof Calendar);
+    }
+
+    @Test
+    public void testReflectUtil_ParseToObject_Returns_Double_Array() throws Exception {
+        List<String> values = Arrays.asList("1.1", "2.2", "3.3");
+        double[] result = (double[]) ReflectUtil.parseToObject("double[]", values);
+        assertNotNull(result);
+        assertEquals(3, result.length);
+        assertEquals(1.1, result[0], 0.0001);
+        assertEquals(2.2, result[1], 0.0001);
+        assertEquals(3.3, result[2], 0.0001);
+    }
+
+    @Test
+    public void testReflectUtil_SetObjectArrayField_Supports_Double_Array() throws Exception {
+        // StoragePerformanceSummary has double[] fields (e.g. datastoreReadLatency).
+        // Prior to the fix, setObjectArrayField threw RuntimeException for double[].
+        StoragePerformanceSummary summary = new StoragePerformanceSummary();
+        Field field = StoragePerformanceSummary.class.getField("datastoreReadLatency");
+        List<String> values = Arrays.asList("0.5", "1.0", "1.5");
+        ReflectUtil.setObjectArrayField(summary, field, "double[]", values);
+        assertNotNull(summary.getDatastoreReadLatency());
+        assertEquals(3, summary.getDatastoreReadLatency().length);
+        assertEquals(0.5, summary.getDatastoreReadLatency()[0], 0.0001);
     }
 }

--- a/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
+++ b/src/test/java/org/doublecloud/ws/util/ReflectUtilTest.java
@@ -101,17 +101,6 @@ public class ReflectUtilTest {
     }
 
     @Test
-    public void testReflectUtil_ParseToObject_Returns_Double_Array() throws Exception {
-        List<String> values = Arrays.asList("1.1", "2.2", "3.3");
-        double[] result = (double[]) ReflectUtil.parseToObject("double[]", values);
-        assertNotNull(result);
-        assertEquals(3, result.length);
-        assertEquals(1.1, result[0], 0.0001);
-        assertEquals(2.2, result[1], 0.0001);
-        assertEquals(3.3, result[2], 0.0001);
-    }
-
-    @Test
     public void testReflectUtil_SetObjectArrayField_Supports_Double_Array() throws Exception {
         // StoragePerformanceSummary has double[] fields (e.g. datastoreReadLatency).
         // Prior to the fix, setObjectArrayField threw RuntimeException for double[].


### PR DESCRIPTION
## Summary

- `ReflectUtil.setObjectArrayField` was throwing `RuntimeException` for any field typed `double[]`, because the dispatch chain covered `int[]`, `short[]`, `byte[]`, `long[]`, `float[]`, and `boolean[]` but silently skipped `double[]`
- `StoragePerformanceSummary` has five `double[]` fields (`datastoreReadLatency`, `datastoreWriteLatency`, `datastoreVmLatency`, `datastoreReadIops`, `datastoreWriteIops`), making it completely undeserializable
- The fix wires the already-existing `toDoubleArray()` helper into the dispatch chain

Closes #243

## Test plan

- [ ] Verify `ReflectUtil.setObjectArrayField` no longer throws for `double[]` fields
- [ ] Confirm `StoragePerformanceSummary` deserializes correctly against a live vCenter

🤖 Generated with [Claude Code](https://claude.com/claude-code)