### PR TITLE
fix: parse missingSet faults correctly and surface localized message (#185)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -172,7 +172,11 @@ abstract public class ManagedObject {
         if (objContent != null) {
             MissingProperty[] missing = objContent.getMissingSet();
             if (missing != null && missing.length > 0 && missing[0].getFault() != null) {
-                throw new RuntimeException(missing[0].getFault().getFault());
+                LocalizedMethodFault lmf = missing[0].getFault();
+                String message = lmf.getLocalizedMessage() != null
+                    ? lmf.getLocalizedMessage()
+                    : "Property '" + propertyName + "' could not be retrieved";
+                throw new RuntimeException(message, lmf.getFault());
             }
 
             DynamicProperty[] dynaProps = objContent.getPropSet();

--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -271,11 +271,17 @@ class XmlGenDom extends XmlGen {
             String tagName = e.getName();
 
             Field field = null;
-            if (TypeUtil.isPrimitiveType(tagName)) {
-                field = clazz.getField("_" + tagName);
+            try {
+                if (TypeUtil.isPrimitiveType(tagName)) {
+                    field = clazz.getField("_" + tagName);
+                }
+                else {
+                    field = clazz.getField(tagName);
+                }
             }
-            else {
-                field = clazz.getField(tagName);
+            catch (NoSuchFieldException nsfe) {
+                log.debug("Skipping unrecognized element '{}' in {}", tagName, clazz.getSimpleName());
+                continue;
             }
 
             Class<?> fType = field.getType();

--- a/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
@@ -80,4 +80,32 @@ public class ManagedObjectCurrentPropertyTest {
             assertNotNull(e.getCause());
         }
     }
+
+    @Test
+    public void getCurrentProperty_runtimeExceptionMessageIsLocalizedMessageFromFault() {
+        MissingProperty missing = new MissingProperty();
+        missing.setPath("config");
+        LocalizedMethodFault lmf = new LocalizedMethodFault();
+        lmf.setFault(new com.vmware.vim25.NoPermission());
+        lmf.setLocalizedMessage("Permission to perform this operation was denied.");
+        missing.setFault(lmf);
+
+        ObjectContent objContent = new ObjectContent();
+        objContent.setMissingSet(new MissingProperty[]{missing});
+
+        TestManagedObject mo = new TestManagedObject(objContent);
+
+        try {
+            mo.testGetCurrentProperty("config");
+            fail("Expected RuntimeException");
+        } catch (RuntimeException e) {
+            assertEquals(
+                "Exception message should be the localized message from the server fault",
+                "Permission to perform this operation was denied.",
+                e.getMessage());
+            assertTrue(
+                "Cause should be the MethodFault so callers can inspect type",
+                e.getCause() instanceof com.vmware.vim25.NoPermission);
+        }
+    }
 }

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -166,4 +166,30 @@ public class XmlGenDomTest {
         InputStream is = new ByteArrayInputStream(payload.getBytes(StandardCharsets.UTF_8));
         new XmlGenDom().fromXML("String", is);
     }
+
+    @Test
+    public void testFromXML_ObjectContentWithMissingSet_ParsesMissingPropertyFault() throws Exception {
+        InputStream inputStream = new FileInputStream(
+            new File("src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithMissingSet.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        ObjectContent objectContent = (ObjectContent) xmlGenDom.fromXML("ObjectContent", inputStream);
+
+        Assert.assertNotNull("missingSet should be populated", objectContent.getMissingSet());
+        Assert.assertEquals(1, objectContent.getMissingSet().length);
+
+        MissingProperty mp = objectContent.getMissingSet()[0];
+        Assert.assertEquals("config", mp.getPath());
+        Assert.assertNotNull("MissingProperty.fault should not be null", mp.getFault());
+        Assert.assertEquals(
+            "Permission to perform this operation was denied.",
+            mp.getFault().getLocalizedMessage());
+        Assert.assertNotNull("LocalizedMethodFault.fault should not be null", mp.getFault().getFault());
+        Assert.assertTrue(
+            "inner fault should be a NoPermission",
+            mp.getFault().getFault() instanceof com.vmware.vim25.NoPermission);
+
+        com.vmware.vim25.NoPermission np =
+            (com.vmware.vim25.NoPermission) mp.getFault().getFault();
+        Assert.assertEquals("System.Read", np.privilegeId);
+    }
 }

--- a/src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithMissingSet.xml
+++ b/src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithMissingSet.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <RetrievePropertiesResponse xmlns="urn:vim25">
+            <returnval>
+                <obj type="VirtualMachine">vm-1</obj>
+                <missingSet>
+                    <path>config</path>
+                    <fault>
+                        <fault xsi:type="NoPermission">
+                            <object type="VirtualMachine">vm-1</object>
+                            <privilegeId>System.Read</privilegeId>
+                            <unknownFutureField>someValue</unknownFutureField>
+                        </fault>
+                        <localizedMessage>Permission to perform this operation was denied.</localizedMessage>
+                    </fault>
+                </missingSet>
+            </returnval>
+        </RetrievePropertiesResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
## Summary

- **`XmlGenDom.fromXml`**: Wrap field lookup in `try/catch NoSuchFieldException` so unknown XML elements in fault subtypes (e.g. fields added by newer vSphere versions not yet in the Java model) are skipped at DEBUG rather than aborting the entire `ObjectContent` parse
- **`ManagedObject.getCurrentProperty`**: Use `LocalizedMethodFault.localizedMessage` as the `RuntimeException` message instead of the fault class name; the `MethodFault` is preserved as the cause so callers can still inspect the type
- Tests added for both fixes following a fail-first TDD approach

## Test Plan

- [x] New test `XmlGenDomTest.testFromXML_ObjectContentWithMissingSet_ParsesMissingPropertyFault` — verifies a SOAP response with a `missingSet` `NoPermission` fault (including an unknown XML element) parses into a fully-populated `LocalizedMethodFault` with the correct inner `NoPermission`
- [x] New test `ManagedObjectCurrentPropertyTest.getCurrentProperty_runtimeExceptionMessageIsLocalizedMessageFromFault` — verifies `e.getMessage()` is the localized string and `e.getCause()` is the typed `MethodFault`
- [x] Full test suite passes with no regressions

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)