### PR TITLE
fix(xml): handle unknown xsi:types and ArrayOf* wrappers without NPE (#156)

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -241,7 +241,12 @@ class XmlGenDom extends XmlGen {
             for (int i = 0; i < subNodes.size(); i++) {
                 Element e = subNodes.get(i);
                 String xsiType = e.attributeValue(SoapConsts.XSI_TYPE);
-                Object o = fromXml(TypeUtil.getVimClass(xsiType == null ? arrayItemTypeName : xsiType), subNodes.get(i));
+                Class<?> itemClass = TypeUtil.getVimClass(xsiType == null ? arrayItemTypeName : xsiType);
+                if (itemClass == null) {
+                    log.debug("Unknown xsi:type '{}' for array element, using base type {}", xsiType, arrayItemTypeName);
+                    itemClass = clazz;
+                }
+                Object o = fromXml(itemClass, subNodes.get(i));
                 Array.set(ao, i, o);
             }
             return ao;
@@ -293,8 +298,25 @@ class XmlGenDom extends XmlGen {
 
             Class fRealType = fType;
             String xsiType = e.attributeValue(SoapConsts.XSI_TYPE);
-            if (xsiType != null && (!xsiType.startsWith("xsd:"))) {
-                fRealType = TypeUtil.getVimClass(xsiType);
+            if (xsiType != null && xsiType.startsWith("ArrayOf")) {
+                String itemTypeName = xsiType.substring("ArrayOf".length());
+                Class<?> itemClass = TypeUtil.getVimClass(itemTypeName);
+                if (itemClass != null) {
+                    field.set(obj, fromXML(itemTypeName + "[]", e));
+                }
+                else {
+                    log.debug("Unknown ArrayOf item type '{}', skipping field", itemTypeName);
+                }
+                continue;
+            }
+            else if (xsiType != null && (!xsiType.startsWith("xsd:"))) {
+                Class resolvedType = TypeUtil.getVimClass(xsiType);
+                if (resolvedType != null) {
+                    fRealType = resolvedType;
+                }
+                else {
+                    log.debug("Unknown xsi:type '{}', falling back to declared field type {}", xsiType, fType.getSimpleName());
+                }
             }
 
             if (fRealType == ManagedObjectReference.class) { // MOR

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -192,4 +192,22 @@ public class XmlGenDomTest {
             (com.vmware.vim25.NoPermission) mp.getFault().getFault();
         Assert.assertEquals("System.Read", np.privilegeId);
     }
+
+    @Test
+    public void testFromXML_PerfCounterInfoWithUnknownSubtype_ParsesGracefully() throws Exception {
+        InputStream inputStream = new FileInputStream(
+            new File("src/test/java/com/vmware/vim25/ws/xml/PerfCounterInfoWithUnknownSubtype.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        ObjectContent objectContent = (ObjectContent) xmlGenDom.fromXML("ObjectContent", inputStream);
+
+        Assert.assertNotNull(objectContent.getPropSet());
+        Assert.assertEquals(1, objectContent.getPropSet().length);
+
+        PerfCounterInfo[] counters = (PerfCounterInfo[]) objectContent.getPropSet()[0].getVal();
+        Assert.assertNotNull("counter array should not be null", counters);
+        Assert.assertEquals("should have parsed both counters", 2, counters.length);
+
+        Assert.assertEquals("first counter key", 1, counters[0].getKey());
+        Assert.assertEquals("unknown-subtype counter key should be 369", 369, counters[1].getKey());
+    }
 }

--- a/src/test/java/com/vmware/vim25/ws/xml/PerfCounterInfoWithUnknownSubtype.xml
+++ b/src/test/java/com/vmware/vim25/ws/xml/PerfCounterInfoWithUnknownSubtype.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <RetrievePropertiesResponse xmlns="urn:vim25">
+            <returnval>
+                <obj type="PerformanceManager">PerfMgr</obj>
+                <propSet>
+                    <name>perfCounter</name>
+                    <val xsi:type="ArrayOfPerfCounterInfo">
+                        <PerfCounterInfo xsi:type="PerfCounterInfo">
+                            <key>1</key>
+                            <nameInfo><label>Usage</label><summary>CPU usage</summary><key>usage</key></nameInfo>
+                            <groupInfo><label>CPU</label><summary>CPU</summary><key>cpu</key></groupInfo>
+                            <unitInfo><label>%</label><summary>Percentage</summary><key>percent</key></unitInfo>
+                            <rollupType>none</rollupType>
+                            <statsType>rate</statsType>
+                            <level>4</level>
+                            <perDeviceLevel>4</perDeviceLevel>
+                        </PerfCounterInfo>
+                        <PerfCounterInfo xsi:type="PerfCounterInfoInt">
+                            <key>369</key>
+                            <nameInfo><label>VXLAN tx throughput</label><summary>Transmitted packet rate</summary><key>throughput.vds.txTotal</key></nameInfo>
+                            <groupInfo><label>Network</label><summary>Network</summary><key>net</key></groupInfo>
+                            <unitInfo><label>num</label><summary>Number</summary><key>number</key></unitInfo>
+                            <rollupType>summation</rollupType>
+                            <statsType>delta</statsType>
+                            <level>4</level>
+                            <perDeviceLevel>4</perDeviceLevel>
+                            <enabledByDefault>false</enabledByDefault>
+                            <enabled>false</enabled>
+                        </PerfCounterInfo>
+                    </val>
+                </propSet>
+            </returnval>
+        </RetrievePropertiesResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
## Summary

- **`XmlGenDom.fromXml`**: Detect `ArrayOf*` xsi:types on Object-typed fields (e.g. `DynamicProperty.val`) and parse them correctly as typed arrays instead of falling into the basic-type branch and exploding
- **`XmlGenDom.fromXML` array branch**: When an array element's xsi:type cannot be resolved by `TypeUtil` (e.g. `PerfCounterInfoInt`, a vCenter 6.0 VXLAN-specific internal subtype not in the public WSDL), fall back to the declared array item type instead of passing `null` to `fromXml` and NPE-ing

**Root cause (issue #156):** vCenter 6.0 with VXLAN/NSX returns `PerfCounterInfo` elements with `xsi:type="PerfCounterInfoInt"` for VXLAN network counters. This type is not in the public VMware WSDL (absent from pyvmomi too). The missing type caused a `NullPointerException` that was wrapped as `RemoteException("Exception in SoapClient.invoke:")`, hiding the real cause from callers.

## Test Plan

- [x] New XML fixture with a real `PerfCounterInfoInt` element from the issue's trace log
- [x] New test `testFromXML_PerfCounterInfoWithUnknownSubtype_ParsesGracefully` confirms both known (`PerfCounterInfo`) and unknown-subtype (`PerfCounterInfoInt`) counters parse successfully with correct keys
- [x] Full test suite passes with no regressions

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)