### PR TITLE
fix(mo): restore renamed public methods as backward-compat aliases

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/Alarm.java
+++ b/src/main/java/com/vmware/vim25/mo/Alarm.java
@@ -30,5 +30,9 @@ public class Alarm extends ExtensibleManagedObject {
     public ManagedEntity getAssociatedEntity() {
         return (ManagedEntity) getManagedObject("info.entity");
     }
+    /** Backward-compat alias for {@link #getInfo()}. */
+    public AlarmInfo getAlarmInfo() {
+        return getInfo();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/AuthorizationManager.java
+++ b/src/main/java/com/vmware/vim25/mo/AuthorizationManager.java
@@ -103,5 +103,9 @@ public EntityPrivilege[] hasPrivilegeOnEntities(ManagedEntity[] entity, String s
     }
     getVimService().setEntityPermissions(getMOR(), entity.getMOR(), permission);
 }
+    /** Backward-compat alias for {@link #updateRole(int, String, String[])}. */
+    public void updateAuthorizationRole(int roleId, String newName, String[] privIds) throws AlreadyExists, InvalidName, NotFound, RuntimeFault, RemoteException {
+        updateRole(roleId, newName, privIds);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/ComputeResource.java
+++ b/src/main/java/com/vmware/vim25/mo/ComputeResource.java
@@ -70,5 +70,9 @@ public class ComputeResource extends ManagedEntity {
     }
 
     /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /** Backward-compat alias for {@link #getNetwork()}. */
+    public Network[] getNetworks() {
+        return getNetwork();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/Datastore.java
+++ b/src/main/java/com/vmware/vim25/mo/Datastore.java
@@ -91,5 +91,9 @@ public class Datastore extends ManagedEntity {
 public StoragePlacementResult datastoreEnterMaintenanceMode() throws InvalidState, RuntimeFault, RemoteException {
     return getVimService().datastoreEnterMaintenanceMode(getMOR());
 }
+    /** Backward-compat alias for {@link #getVm()}. */
+    public VirtualMachine[] getVms() {
+        return getVm();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/DiagnosticManager.java
+++ b/src/main/java/com/vmware/vim25/mo/DiagnosticManager.java
@@ -38,5 +38,9 @@ public class DiagnosticManager extends ManagedObject {
     public DiagnosticManagerLogDescriptor[] queryDescriptions(HostSystem host) throws RuntimeFault, RemoteException {
     return getVimService().queryDescriptions(getMOR(), host == null ? null : host.getMOR());
 }
+    /** Backward-compat alias for {@link #generateLogBundles(boolean, HostSystem[])}. */
+    public Task generateLogBundles_Task(boolean includeDefault, HostSystem[] hosts) throws LogBundlingFailed, TaskInProgress, RuntimeFault, RemoteException {
+        return generateLogBundles(includeDefault, hosts);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/DistributedVirtualSwitch.java
+++ b/src/main/java/com/vmware/vim25/mo/DistributedVirtualSwitch.java
@@ -148,5 +148,9 @@ public class DistributedVirtualSwitch extends ManagedEntity {
     ManagedObjectReference mor = getVimService().rectifyDvsHost_Task(getMOR(), mors);
     return new Task(getServerConnection(), mor);
 }
+    /** Backward-compat array overload of {@link #addDVPortgroups_Task(DVPortgroupConfigSpec[])}. */
+    public Task addDVPortgroup_Task(DVPortgroupConfigSpec[] spec) throws DvsFault, DuplicateName, InvalidName, RuntimeFault, RemoteException {
+        return addDVPortgroups_Task(spec);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/DistributedVirtualSwitchManager.java
+++ b/src/main/java/com/vmware/vim25/mo/DistributedVirtualSwitchManager.java
@@ -98,5 +98,14 @@ public Task rectifyDvsOnHost_Task(HostSystem[] hosts) throws DvsFault, RuntimeFa
     ManagedObjectReference resultMor = getVimService().queryDvsByUuid(getMOR(), uuid);
     return new DistributedVirtualSwitch(getServerConnection(), resultMor);
 }
+    /**
+     * Look up a DVPortgroup by switch UUID + portgroup key. This is a distinct
+     * SOAP operation from {@link #lookupDvPortGroup(String)} (which looks up by
+     * portgroup key only within the current scope).
+     */
+    public DistributedVirtualPortgroup dVSManagerLookupDvPortGroup(String switchUuid, String portgroupKey) throws NotFound, RuntimeFault, RemoteException {
+        ManagedObjectReference mor = getVimService().dVSManagerLookupDvPortGroup(getMOR(), switchUuid, portgroupKey);
+        return new DistributedVirtualPortgroup(getServerConnection(), mor);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/FileManager.java
+++ b/src/main/java/com/vmware/vim25/mo/FileManager.java
@@ -42,5 +42,13 @@ public class FileManager extends ManagedObject {
     }
 
     /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /** Backward-compat alias for {@link #copyFile(String, Datacenter, String, Datacenter, boolean)}. */
+    public Task copyDatastoreFile_Task(String sourceName, Datacenter sourceDatacenter, String destinationName, Datacenter destinationDatacenter, boolean force) throws FileFault, InvalidDatastore, RuntimeFault, RemoteException {
+        return copyFile(sourceName, sourceDatacenter, destinationName, destinationDatacenter, force);
+    }
+    /** Backward-compat alias for {@link #deleteFile(String, Datacenter)}. */
+    public Task deleteDatastoreFile_Task(String name, Datacenter datacenter) throws FileFault, InvalidDatastore, RuntimeFault, RemoteException {
+        return deleteFile(name, datacenter);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/Folder.java
+++ b/src/main/java/com/vmware/vim25/mo/Folder.java
@@ -120,5 +120,9 @@ public Task addStandaloneHost_Task(HostConnectSpec spec, ComputeResourceConfigSp
     public Task unregisterAndDestroy_Task() throws InvalidState, ConcurrentAccess, RuntimeFault, RemoteException {
     return new Task(getServerConnection(), getVimService().unregisterAndDestroy_Task(getMOR()));
 }
+    /** Backward-compat alias for {@link #createDistributedVirtualSwitch(DVSCreateSpec)}. */
+    public Task createDVS_Task(DVSCreateSpec spec) throws DvsNotAuthorized, DvsFault, DuplicateName, InvalidName, NotFound, RuntimeFault, RemoteException {
+        return createDistributedVirtualSwitch(spec);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/HostDatastoreBrowser.java
+++ b/src/main/java/com/vmware/vim25/mo/HostDatastoreBrowser.java
@@ -27,6 +27,10 @@ public class HostDatastoreBrowser extends ManagedObject {
     }
 
     /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /** Backward-compat alias for {@link #getDatastore()}. */
+    public Datastore[] getDatastores() {
+        return getDatastore();
+    }
     public Task searchDatastore_Task(String datastorePath, HostDatastoreBrowserSearchSpec searchSpec) throws FileFault, InvalidDatastore, RuntimeFault, RemoteException {
     return new Task(getServerConnection(), getVimService().searchDatastore_Task(getMOR(), datastorePath, searchSpec));
 }

--- a/src/main/java/com/vmware/vim25/mo/HostEsxAgentHostManager.java
+++ b/src/main/java/com/vmware/vim25/mo/HostEsxAgentHostManager.java
@@ -26,5 +26,9 @@ public class HostEsxAgentHostManager extends ManagedObject {
     }
 
     /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /** Backward-compat alias for {@link #getConfigInfo()}. */
+    public HostEsxAgentHostManagerConfigInfo getCacheConfigurationInfo() {
+        return getConfigInfo();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/HostServiceSystem.java
+++ b/src/main/java/com/vmware/vim25/mo/HostServiceSystem.java
@@ -43,5 +43,17 @@ public class HostServiceSystem extends ExtensibleManagedObject {
     }
 
     /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /** Backward-compat alias for {@link #start(String)}. */
+    public void startService(String id) throws HostConfigFault, InvalidState, NotFound, RuntimeFault, RemoteException {
+        start(id);
+    }
+    /** Backward-compat alias for {@link #stop(String)}. */
+    public void stopService(String id) throws HostConfigFault, InvalidState, NotFound, RuntimeFault, RemoteException {
+        stop(id);
+    }
+    /** Backward-compat alias for {@link #restart(String)}. */
+    public void restartService(String id) throws HostConfigFault, InvalidState, NotFound, RuntimeFault, RemoteException {
+        restart(id);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/HostSystem.java
+++ b/src/main/java/com/vmware/vim25/mo/HostSystem.java
@@ -336,5 +336,17 @@ public HostVsanInternalSystem getHostVsanInternalSystem() throws InvalidProperty
 public HostVsanSystem getHostVsanSystem() throws InvalidProperty, RuntimeFault, RemoteException {
     return (HostVsanSystem) MorUtil.createExactManagedObject(getServerConnection(), getConfigManager().getVsanSystem());
 }
+    /** Backward-compat alias for {@link #getNetwork()}. */
+    public Network[] getNetworks() {
+        return getNetwork();
+    }
+    /** Backward-compat alias for {@link #getDatastore()}. */
+    public Datastore[] getDatastores() {
+        return getDatastore();
+    }
+    /** Backward-compat alias for {@link #getVm()}. */
+    public VirtualMachine[] getVms() {
+        return getVm();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/LicenseManager.java
+++ b/src/main/java/com/vmware/vim25/mo/LicenseManager.java
@@ -117,5 +117,21 @@ public LicenseManagerLicenseInfo decodeLicense(String licenseKey) throws Runtime
     public LicenseFeatureInfo[] querySupportedFeatures(HostSystem host) throws RuntimeFault, RemoteException {
     return getVimService().querySupportedFeatures(getMOR(), host == null ? null : host.getMOR());
 }
+    /** Backward-compat alias for {@link #configureSource(HostSystem, LicenseSource)}. */
+    public void configureLicenseSource(HostSystem host, LicenseSource licenseSource) throws CannotAccessLocalSource, InvalidLicense, LicenseServerUnavailable, RuntimeFault, RemoteException {
+        configureSource(host, licenseSource);
+    }
+    /** Backward-compat alias for {@link #setEdition(HostSystem, String)}. */
+    public void setLicenseEdition(HostSystem host, String featureKey) throws InvalidState, LicenseServerUnavailable, RuntimeFault, RemoteException {
+        setEdition(host, featureKey);
+    }
+    /** Backward-compat alias for {@link #enable(HostSystem, String)}; ignores boolean return. */
+    public void enableFeature(HostSystem host, String featureKey) throws InvalidState, LicenseServerUnavailable, RuntimeFault, RemoteException {
+        enable(host, featureKey);
+    }
+    /** Backward-compat alias for {@link #disable(HostSystem, String)}; ignores boolean return. */
+    public void disableFeature(HostSystem host, String featureKey) throws InvalidState, LicenseServerUnavailable, RuntimeFault, RemoteException {
+        disable(host, featureKey);
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/ScheduledTaskManager.java
+++ b/src/main/java/com/vmware/vim25/mo/ScheduledTaskManager.java
@@ -60,5 +60,9 @@ public ScheduledTask[] retrieveObjectScheduledTask(ManagedObject obj) throws Run
     }
     return tasks;
 }
+    /** Backward-compat alias for {@link #getScheduledTask()}. */
+    public ScheduledTask[] getScheduledTasks() {
+        return getScheduledTask();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/TaskManager.java
+++ b/src/main/java/com/vmware/vim25/mo/TaskManager.java
@@ -62,5 +62,9 @@ public TaskInfo createTask(ManagedObject obj, String taskTypeId, String initiate
     }
     return getVimService().createTask(getMOR(), obj.getMOR(), taskTypeId, initiatedBy, cancelable, parentTaskKey, activationId);
 }
+    /** Backward-compat alias for {@link #getRecentTask()}. */
+    public Task[] getRecentTasks() {
+        return getRecentTask();
+    }
     /* ===== END custom ===== */
 }

--- a/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
+++ b/src/main/java/com/vmware/vim25/mo/VirtualMachine.java
@@ -453,5 +453,9 @@ public Task removeAllSnapshots_Task() throws SnapshotFault, TaskInProgress, Inva
 public Task revertToCurrentSnapshot_Task(HostSystem host) throws VmConfigFault, SnapshotFault, TaskInProgress, InvalidState, InsufficientResourcesFault, NotFound, RuntimeFault, RemoteException {
     return revertToCurrentSnapshot_Task(host, false);
 }
+    /** Backward-compat alias for {@link #getDatastore()}. */
+    public Datastore[] getDatastores() {
+        return getDatastore();
+    }
     /* ===== END custom ===== */
 }


### PR DESCRIPTION
## Summary

The 9.0 regen merged in #321 renamed many public methods to drop common prefixes/suffixes (`startService` → `start`, `getNetworks` → `getNetwork`, `configureLicenseSource` → `configureSource`, `getRecentTasks` → `getRecentTask`, etc.). These renames broke downstream consumers — discovered by trying to build [yavijava-samples](https://github.com/yavijava/yavijava-samples) against the post-merge yavijava 9.0-SNAPSHOT (68 compile errors across 19 sample files).

Restoring the original names as thin delegating aliases inside the preserved custom fences. Both names now resolve to the same WSDL operation; the new shorter names remain available for those who prefer them.

All 219 yavijava tests pass; yavijava-samples builds cleanly with this change applied.

## Aliases added (17 files, 19 methods)

**Public API regressions surfaced by the samples build:**
- `AuthorizationManager.updateAuthorizationRole` → `updateRole`
- `ComputeResource.getNetworks` → `getNetwork`
- `Datastore.getVms` → `getVm`
- `DiagnosticManager.generateLogBundles_Task` → `generateLogBundles`
- `DistributedVirtualSwitch.addDVPortgroup_Task(spec[])` → `addDVPortgroups_Task`
- `DistributedVirtualSwitchManager.dVSManagerLookupDvPortGroup` (distinct SOAP op from `lookupDvPortGroup` — takes `switchUuid + portgroupKey`, was lost entirely in the regen)
- `FileManager.copyDatastoreFile_Task` → `copyFile`
- `FileManager.deleteDatastoreFile_Task` → `deleteFile`
- `Folder.createDVS_Task` → `createDistributedVirtualSwitch`
- `HostDatastoreBrowser.getDatastores` → `getDatastore`
- `HostServiceSystem.startService/stopService/restartService` → `start/stop/restart`
- `HostSystem.getNetworks/getDatastores/getVms` → singular versions
- `LicenseManager.configureLicenseSource/setLicenseEdition/enableFeature/disableFeature` → `configureSource/setEdition/enable/disable`
- `ScheduledTaskManager.getScheduledTasks` → `getScheduledTask`
- `TaskManager.getRecentTasks` → `getRecentTask`
- `VirtualMachine.getDatastores` → `getDatastore`

**Audit-flagged renames also restored for the same reason:**
- `Alarm.getAlarmInfo` → `getInfo`
- `HostEsxAgentHostManager.getCacheConfigurationInfo` → `getConfigInfo`

## Why aliases inside the custom fence

Putting them inside the `/* ===== BEGIN/END custom ===== */` markers ensures the regenerator preserves them on future runs. If we instead waited for the next regen to "fix the names back," any downstream consumer code in the wild would still be broken between releases.

## Test plan

- [x] `./gradlew test` — 219 tests, 0 failures
- [x] `./gradlew publishToMavenLocal && cd ../yavijava-samples && ./gradlew compileJava` — 0 errors
- [ ] Smoke-test against a live vCenter (out of scope for this PR; covered by separate yavijava-samples smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)