### PR TITLE
fix(deps): bump httpclient5 and logback-classic for CVE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
 dependencies {
     implementation 'org.dom4j:dom4j:2.1.4'
     implementation 'org.slf4j:slf4j-api:2.0.17'
-    testRuntimeOnly 'ch.qos.logback:logback-classic:1.5.18'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
+    testRuntimeOnly 'ch.qos.logback:logback-classic:1.5.32'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.3'
     compileOnly 'org.projectlombok:lombok:1.18.36'
     annotationProcessor 'org.projectlombok:lombok:1.18.36'
     testImplementation 'javax.servlet:javax.servlet-api:3.1.0'


### PR DESCRIPTION
## Summary

Two dependencies with known CVEs bumped; all tests pass.

| Dependency | Old | New | CVE | Impact |
|---|---|---|---|---|
| `httpclient5` | 5.4.1 | 5.4.3 | [CVE-2025-27820](https://vulert.com/vuln-db/CVE-2025-27820) | PSL validation bug disables domain checks — cookie hijacking / MITM possible. **Production dep, in hot path of every SOAP call.** |
| `logback-classic` | 1.5.18 | 1.5.32 | [CVE-2025-11226](https://nvd.nist.gov/vuln/detail/CVE-2025-11226) | ACE via malicious logback config file. `testRuntimeOnly` only — not shipped to library users. |

No other dependencies had open CVEs (`dom4j` 2.1.4's CVE-2023-45960 is disputed by the vendor; Groovy 4.0.24 has none).

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)