### PR TITLE
feat(mo): add FailoverClusterConfigurator and FailoverClusterManager wrappers

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/FailoverClusterConfigurator.java
+++ b/src/main/java/com/vmware/vim25/mo/FailoverClusterConfigurator.java
@@ -1,0 +1,52 @@
+// auto generated using yavijava_generator
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.*;
+import java.rmi.RemoteException;
+
+/* ===== BEGIN custom imports (preserved by regenerator) ===== */
+/* ===== END custom imports ===== */
+
+public class FailoverClusterConfigurator extends ManagedObject {
+
+    public FailoverClusterConfigurator(ServerConnection serverConnection, ManagedObjectReference mor) {
+        super(serverConnection, mor);
+    }
+
+    public Task configureVcha_Task(VchaClusterConfigSpec configSpec) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().configureVcha_Task(getMOR(), configSpec);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public Task createPassiveNode_Task(PassiveNodeDeploymentSpec passiveDeploymentSpec, SourceNodeSpec sourceVcSpec) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().createPassiveNode_Task(getMOR(), passiveDeploymentSpec, sourceVcSpec);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public Task createWitnessNode_Task(NodeDeploymentSpec witnessDeploymentSpec, SourceNodeSpec sourceVcSpec) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().createWitnessNode_Task(getMOR(), witnessDeploymentSpec, sourceVcSpec);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public Task deployVcha_Task(VchaClusterDeploymentSpec deploymentSpec) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().deployVcha_Task(getMOR(), deploymentSpec);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public Task destroyVcha_Task() throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().destroyVcha_Task(getMOR());
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public VchaClusterConfigInfo getVchaConfig() throws RuntimeFault, RemoteException {
+        return getVimService().getVchaConfig(getMOR());
+    }
+
+    public Task prepareVcha_Task(VchaClusterNetworkSpec networkSpec) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().prepareVcha_Task(getMOR(), networkSpec);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /* ===== END custom ===== */
+}

--- a/src/main/java/com/vmware/vim25/mo/FailoverClusterManager.java
+++ b/src/main/java/com/vmware/vim25/mo/FailoverClusterManager.java
@@ -1,0 +1,36 @@
+// auto generated using yavijava_generator
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.*;
+import java.rmi.RemoteException;
+
+/* ===== BEGIN custom imports (preserved by regenerator) ===== */
+/* ===== END custom imports ===== */
+
+public class FailoverClusterManager extends ManagedObject {
+
+    public FailoverClusterManager(ServerConnection serverConnection, ManagedObjectReference mor) {
+        super(serverConnection, mor);
+    }
+
+    public String getClusterMode() throws RuntimeFault, RemoteException {
+        return getVimService().getClusterMode(getMOR());
+    }
+
+    public VchaClusterHealth getVchaClusterHealth() throws RuntimeFault, RemoteException {
+        return getVimService().getVchaClusterHealth(getMOR());
+    }
+
+    public Task initiateFailover_Task(boolean planned) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().initiateFailover_Task(getMOR(), planned);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    public Task setClusterMode_Task(String mode) throws RuntimeFault, RemoteException {
+        ManagedObjectReference resultMor = getVimService().setClusterMode_Task(getMOR(), mode);
+        return new Task(getServerConnection(), resultMor);
+    }
+
+    /* ===== BEGIN custom (preserved by regenerator) ===== */
+    /* ===== END custom ===== */
+}

--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -292,6 +292,12 @@ public class ServiceInstance extends ManagedObject {
     public IoFilterManager getIoFilterManager() {
     return (IoFilterManager) createMO(getServiceContent().getIoFilterManager());
 }
+    public FailoverClusterConfigurator getFailoverClusterConfigurator() {
+    return (FailoverClusterConfigurator) createMO(getServiceContent().getFailoverClusterConfigurator());
+}
+    public FailoverClusterManager getFailoverClusterManager() {
+    return (FailoverClusterManager) createMO(getServiceContent().getFailoverClusterManager());
+}
     private ManagedObject createMO(ManagedObjectReference mor) {
     return MorUtil.createExactManagedObject(getServerConnection(), mor);
 }


### PR DESCRIPTION
## Summary

Adds `mo/` convenience wrappers for the two VCHA managed objects that have been in the WSDL since vSphere 6.5 but were never wrapped. Closes #322.

### `FailoverClusterConfigurator`
- `configureVcha_Task(VchaClusterConfigSpec)` → `Task`
- `createPassiveNode_Task(PassiveNodeDeploymentSpec, SourceNodeSpec)` → `Task`
- `createWitnessNode_Task(NodeDeploymentSpec, SourceNodeSpec)` → `Task`
- `deployVcha_Task(VchaClusterDeploymentSpec)` → `Task`
- `destroyVcha_Task()` → `Task`
- `getVchaConfig()` → `VchaClusterConfigInfo`
- `prepareVcha_Task(VchaClusterNetworkSpec)` → `Task`

### `FailoverClusterManager`
- `getClusterMode()` → `String`
- `getVchaClusterHealth()` → `VchaClusterHealth`
- `initiateFailover_Task(boolean planned)` → `Task`
- `setClusterMode_Task(String mode)` → `Task`

`ServiceInstance` now also exposes `getFailoverClusterConfigurator()` and `getFailoverClusterManager()` accessors, consistent with all other manager wrappers.

Both classes follow the standard `mo/` pattern (generator fence stamps, `(ServerConnection, ManagedObjectReference)` constructor so `MorUtil.createExactManagedObject` works).

## Test plan

- [x] `./gradlew test` — BUILD SUCCESSFUL
- [ ] Smoke test against a vCenter with VCHA configured (lab has single-node vCenter, so VCHA MORs are not present — instantiation via `MorUtil` is covered by the existing pattern used for all other managers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)