### PR TITLE
fix: paginated property retrieval in InventoryNavigator (#177)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
+++ b/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
@@ -7,6 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class InventoryNavigator {
     private ManagedEntity rootEntity = null;
@@ -101,7 +103,24 @@ public class InventoryNavigator {
         spec.setObjectSet(new ObjectSpec[]{os});
         spec.setPropSet(propspecary);
 
-        return pc.retrieveProperties(new PropertyFilterSpec[]{spec});
+        RetrieveOptions retrieveOptions = new RetrieveOptions();
+        List<ObjectContent> allObjects = new ArrayList<>();
+
+        RetrieveResult result = pc.retrievePropertiesEx(new PropertyFilterSpec[]{spec}, retrieveOptions);
+        while (result != null) {
+            if (result.getObjects() != null) {
+                for (ObjectContent oc : result.getObjects()) {
+                    allObjects.add(oc);
+                }
+            }
+            String token = result.getToken();
+            if (token == null) {
+                break;
+            }
+            result = pc.continueRetrievePropertiesEx(token);
+        }
+
+        return allObjects.isEmpty() ? null : allObjects.toArray(new ObjectContent[0]);
     }
 
     private ManagedEntity[] createManagedEntities(ObjectContent[] ocs) {

--- a/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
+++ b/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.*;
 public class InventoryNavigatorTest {
 
     // Configures a sequence of pages; retrievePropertiesEx returns first, continueRetrievePropertiesEx returns the rest.
+    // retrieveProperties (the old deprecated path) returns only the first page's objects, so multi-page tests fail
+    // with the correct assertion error rather than NPE when run against unfixed code.
     static class StubPropertyCollector extends PropertyCollector {
         private final List<RetrieveResult> pages;
         private int callCount = 0;
@@ -19,6 +21,12 @@ public class InventoryNavigatorTest {
         StubPropertyCollector(RetrieveResult... pages) {
             super(null, null);
             this.pages = Arrays.asList(pages);
+        }
+
+        @Override
+        public ObjectContent[] retrieveProperties(PropertyFilterSpec[] specSet)
+                throws InvalidProperty, RuntimeFault, RemoteException {
+            return pages.isEmpty() ? null : pages.get(0).getObjects();
         }
 
         @Override

--- a/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
+++ b/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
@@ -1,0 +1,129 @@
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.*;
+import org.junit.Test;
+
+import java.rmi.RemoteException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class InventoryNavigatorTest {
+
+    // Configures a sequence of pages; retrievePropertiesEx returns first, continueRetrievePropertiesEx returns the rest.
+    static class StubPropertyCollector extends PropertyCollector {
+        private final List<RetrieveResult> pages;
+        private int callCount = 0;
+
+        StubPropertyCollector(RetrieveResult... pages) {
+            super(null, null);
+            this.pages = Arrays.asList(pages);
+        }
+
+        @Override
+        public RetrieveResult retrievePropertiesEx(PropertyFilterSpec[] specSet, RetrieveOptions options)
+                throws InvalidProperty, RuntimeFault, RemoteException {
+            return pages.isEmpty() ? null : pages.get(callCount++);
+        }
+
+        @Override
+        public RetrieveResult continueRetrievePropertiesEx(String token)
+                throws InvalidProperty, RuntimeFault, RemoteException {
+            return pages.get(callCount++);
+        }
+    }
+
+    static class StubServiceInstance extends ServiceInstance {
+        private final PropertyCollector pc;
+
+        StubServiceInstance(PropertyCollector pc) {
+            super(new ServerConnection(null, null, null));
+            this.pc = pc;
+        }
+
+        @Override
+        public PropertyCollector getPropertyCollector() {
+            return pc;
+        }
+
+        @Override
+        public AboutInfo getAboutInfo() {
+            AboutInfo ai = new AboutInfo();
+            ai.apiVersion = "7.0.0";
+            return ai;
+        }
+    }
+
+    private InventoryNavigator makeNavigator(StubPropertyCollector stubPc) {
+        StubServiceInstance si = new StubServiceInstance(stubPc);
+        ServerConnection sc = new ServerConnection(null, null, si);
+        ManagedObjectReference rootMor = new ManagedObjectReference();
+        rootMor.setType("Folder");
+        rootMor.setVal("group-d1");
+        ManagedEntity root = new ManagedEntity(sc, rootMor) {};
+        return new InventoryNavigator(root);
+    }
+
+    private ObjectContent folderContent(String val) {
+        ManagedObjectReference mor = new ManagedObjectReference();
+        mor.setType("Folder");
+        mor.setVal(val);
+        ObjectContent oc = new ObjectContent();
+        oc.setObj(mor);
+        return oc;
+    }
+
+    private RetrieveResult page(String token, ObjectContent... objects) {
+        RetrieveResult r = new RetrieveResult();
+        r.token = token;
+        r.objects = objects.length > 0 ? objects : null;
+        return r;
+    }
+
+    @Test
+    public void searchManagedEntities_singlePage_returnsAllObjects() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector(
+            page(null, folderContent("folder-1"), folderContent("folder-2"), folderContent("folder-3"))
+        );
+
+        ManagedEntity[] result = makeNavigator(stubPc).searchManagedEntities("Folder");
+
+        assertEquals(3, result.length);
+    }
+
+    @Test
+    public void searchManagedEntities_multiPage_accumulatesAcrossPages() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector(
+            page("page2-token", folderContent("folder-1"), folderContent("folder-2")),
+            page(null,           folderContent("folder-3"), folderContent("folder-4"))
+        );
+
+        ManagedEntity[] result = makeNavigator(stubPc).searchManagedEntities("Folder");
+
+        assertEquals(4, result.length);
+    }
+
+    @Test
+    public void searchManagedEntities_emptyPage_returnsEmptyArray() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector(
+            page(null) // no objects
+        );
+
+        ManagedEntity[] result = makeNavigator(stubPc).searchManagedEntities("Folder");
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+
+    @Test
+    public void searchManagedEntities_nullTypeinfo_returnsEmptyArray() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector();
+        InventoryNavigator nav = makeNavigator(stubPc);
+
+        ManagedEntity[] result = nav.searchManagedEntities(null, true);
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the deprecated `PropertyCollector.retrieveProperties()` call in `InventoryNavigator.retrieveObjectContents()` with a paginated loop using `retrievePropertiesEx` + `continueRetrievePropertiesEx`
- Eliminates the unbounded single-response fetch that caused OOM crashes on large vCenter inventories
- Closes #177

## What changed

`retrieveProperties` returns all matching objects in one response with no upper bound. On a vCenter managing thousands of VMs, hosts, or datastores, this response can exhaust Java heap. The paginated API (`retrievePropertiesEx`) returns a token when there are more results; callers loop with `continueRetrievePropertiesEx` until the token is null.

`RetrieveOptions` is passed without a `maxObjects` cap, letting the server use its default page size — this matches the behaviour the issue reporter described as correct.

## Test plan

- [ ] Build passes: `./gradlew compileJava`
- [ ] Run smoke tests against a live vCenter to confirm `searchManagedEntities` still returns correct results
- [ ] Verify large inventories no longer OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)