### PR TITLE
feat(mo): add locale parameter to ServiceInstance constructors (#262)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -45,6 +45,9 @@ public class ServiceInstance extends ManagedObject {
     SERVICE_INSTANCE_MOR.setType("ServiceInstance");
 }
     protected void constructServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, TrustManager trustManager) throws RemoteException, MalformedURLException {
+    constructServiceInstance(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout, trustManager, null);
+}
+    protected void constructServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, TrustManager trustManager, String locale) throws RemoteException, MalformedURLException {
     if (url == null || username == null) {
         throw new NullPointerException("None of url, username can be null.");
     }
@@ -58,7 +61,7 @@ public class ServiceInstance extends ManagedObject {
     //with new SOAP_ACTION
     serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
     setServerConnection(new ServerConnection(url, vimService, this));
-    UserSession userSession = login(getSessionManager(), username, password, null);
+    UserSession userSession = login(getSessionManager(), username, password, locale);
     getServerConnection().setUserSession(userSession);
 }
     protected void constructServiceInstance(URL url, String sessionStr, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, TrustManager trustManager) throws RemoteException, MalformedURLException {
@@ -114,6 +117,14 @@ public class ServiceInstance extends ManagedObject {
     public ServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout) throws RemoteException, MalformedURLException {
     super(null, null);
     constructServiceInstance(url, username, password, false, namespace, connectTimeout, readTimeout, trustManager);
+}
+    public ServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, String locale) throws RemoteException, MalformedURLException {
+    super(null, null);
+    constructServiceInstance(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout, null, locale);
+}
+    public ServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout, String locale) throws RemoteException, MalformedURLException {
+    super(null, null);
+    constructServiceInstance(url, username, password, false, namespace, connectTimeout, readTimeout, trustManager, locale);
 }
     public ServiceInstance(URL url, String sessionStr, boolean ignoreCert) throws RemoteException, MalformedURLException {
     this(url, sessionStr, ignoreCert, VIM25_NAMESPACE);

--- a/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
@@ -294,11 +294,69 @@ public class ServiceInstanceTest {
         }
     }
 
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndIgnoreCertsAndLocaleWithTimeouts() {
+        try {
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", true, ServiceInstance.VIM25_NAMESPACE, 2000, 5000, "fr_FR");
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertNull(si.getTrustManager());
+            Assert.assertEquals("fr_FR", si.getCapturedLocale());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateServiceInstanceForUsernameAndPasswordAndTrustManagerAndLocaleWithTimeouts() {
+        try {
+            TestTrustManager testTrustManager = new TestTrustManager();
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", testTrustManager, ServiceInstance.VIM25_NAMESPACE, 2000, 5000, "ja_JP");
+
+            Assert.assertEquals(2000, si.getConnectTimeout());
+            Assert.assertEquals(5000, si.getReadTimeout());
+            Assert.assertEquals(testTrustManager, si.getTrustManager());
+            Assert.assertEquals("ja_JP", si.getCapturedLocale());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testExistingConstructorPassesNullLocale() {
+        try {
+            TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", true, ServiceInstance.VIM25_NAMESPACE, 2000, 5000);
+
+            Assert.assertNull("existing constructor must not change behavior — locale should be null", si.getCapturedLocale());
+        } catch(MalformedURLException e) {
+            Assert.fail("An error occurred creating a service instance due its url being malformed. " + e.getMessage());
+        } catch(RemoteException e) {
+            Assert.fail("An error occurred creating and reading from service instance. " + e.getMessage());
+        }
+    }
+
     private class TestServiceInstance extends ServiceInstance {
+
+        private String capturedLocale;
 
         private TestServiceInstance(URL url, String username, String password)
                 throws RemoteException, MalformedURLException {
             super(url, username, password);
+        }
+
+        private TestServiceInstance(URL url, String username, String password, boolean ignoreCert, String namespace, int connectTimeout, int readTimeout, String locale)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, ignoreCert, namespace, connectTimeout, readTimeout, locale);
+        }
+
+        private TestServiceInstance(URL url, String username, String password, TrustManager trustManager, String namespace, int connectTimeout, int readTimeout, String locale)
+                throws RemoteException, MalformedURLException {
+            super(url, username, password, trustManager, namespace, connectTimeout, readTimeout, locale);
         }
 
         private TestServiceInstance(URL url, String username, String password, boolean ignoreCert)
@@ -388,7 +446,12 @@ public class ServiceInstanceTest {
 
         @Override
         protected UserSession login(SessionManager sessionManager, String userName, String password, String locale) {
+            this.capturedLocale = locale;
             return new UserSession();
+        }
+
+        public String getCapturedLocale() {
+            return capturedLocale;
         }
 
         @Override


### PR DESCRIPTION
## Summary

- Adds two new `ServiceInstance` constructors that accept a `String locale`, threading it through `constructServiceInstance` to the existing `login(SessionManager, String, String, String)` method
- Existing constructors are unchanged in behavior — they pass `null` for locale, which matches today's hard-coded value
- Closes #262

## Why two constructors, not full Cartesian expansion

The username/password constructor surface already has ~10 overloads. Doubling it for a locale variant of every shape would be more clutter than the feature warrants. Instead, the new constructors live on the deepest "everything" shape — once for `boolean ignoreCert` and once for `TrustManager`. Callers needing locale go through one of those two; the rest of the matrix continues to behave exactly as before.

The session-string constructors don't get a locale variant because that path doesn't call `login()` — you've already authenticated elsewhere.

## Test plan

- [x] All existing `ServiceInstanceTest` cases pass unchanged
- [x] New test verifies the `ignoreCert` locale constructor propagates the locale to `login()`
- [x] New test verifies the `TrustManager` locale constructor propagates the locale to `login()`
- [x] Regression test verifies the existing constructor still passes `null` for locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)