### PR TITLE
feat(mo): bounded wait in Task.waitForTask (#238)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/Task.java
+++ b/src/main/java/com/vmware/vim25/mo/Task.java
@@ -6,6 +6,7 @@ import com.vmware.vim25.mo.util.MorUtil;
 import java.rmi.RemoteException;
 
 /* ===== BEGIN custom imports (preserved by regenerator) ===== */
+import java.util.concurrent.TimeoutException;
 /* ===== END custom imports ===== */
 
 public class Task extends ExtensibleManagedObject {
@@ -90,7 +91,23 @@ public String waitForMe() throws InvalidProperty, RuntimeFault, RemoteException 
  * @author Eric Forgette (forgette@netapp.com)
  */
 public String waitForTask() throws RuntimeFault, RemoteException, InterruptedException {
-    return waitForTask(500, 1000);
+    try {
+        return waitForTask(500, 1000, 0L);
+    } catch (TimeoutException impossible) {
+        // 0L means no timeout, so this branch is unreachable
+        throw new IllegalStateException(impossible);
+    }
+}
+    /**
+ * Wait for the task to complete, giving up after maxWaitMillis.
+ * Uses the default poll intervals (500ms running, 1000ms queued).
+ *
+ * @param maxWaitMillis maximum time to wait before giving up; 0 or negative means wait forever
+ * @return String based on TaskInfoState
+ * @throws TimeoutException if maxWaitMillis elapses before the task reaches a terminal state
+ */
+public String waitForTask(long maxWaitMillis) throws RuntimeFault, RemoteException, InterruptedException, TimeoutException {
+    return waitForTask(500, 1000, maxWaitMillis);
 }
     /**
  * Copyright 2009 NetApp, contribution by Eric Forgette
@@ -116,10 +133,33 @@ public String waitForTask() throws RuntimeFault, RemoteException, InterruptedExc
  * @author Eric Forgette (forgette@netapp.com)
  */
 public String waitForTask(int runningDelayInMillSecond, int queuedDelayInMillSecond) throws RuntimeFault, RemoteException, InterruptedException {
+    try {
+        return waitForTask(runningDelayInMillSecond, queuedDelayInMillSecond, 0L);
+    } catch (TimeoutException impossible) {
+        // 0L means no timeout, so this branch is unreachable
+        throw new IllegalStateException(impossible);
+    }
+}
+    /**
+ * Same as {@link #waitForTask(int, int)} but bounded by a maximum wait time.
+ * If the task has not reached a terminal state (success or error) within
+ * {@code maxWaitMillis}, throws {@link TimeoutException}. The task itself is
+ * not cancelled — call {@link #cancelTask()} from the caller if desired.
+ *
+ * @param runningDelayInMillSecond number of milliseconds to sleep between polls for a running task
+ * @param queuedDelayInMillSecond  number of milliseconds to sleep between polls for a queued task
+ * @param maxWaitMillis            maximum time to wait before giving up; 0 or negative means wait forever
+ * @return String based on TaskInfoState
+ * @throws TimeoutException if maxWaitMillis elapses before the task reaches a terminal state
+ */
+public String waitForTask(int runningDelayInMillSecond, int queuedDelayInMillSecond, long maxWaitMillis) throws RuntimeFault, RemoteException, InterruptedException, TimeoutException {
     TaskInfoState tState = null;
     int tries = 0;
     int maxTries = 3;
     Exception getInfoException = null;
+    long deadlineNanos = maxWaitMillis > 0L
+        ? System.nanoTime() + maxWaitMillis * 1_000_000L
+        : 0L;
     while ((tState == null) || tState.equals(TaskInfoState.running) || tState.equals(TaskInfoState.queued)) {
         tState = null;
         getInfoException = null;
@@ -144,6 +184,12 @@ public String waitForTask(int runningDelayInMillSecond, int queuedDelayInMillSec
                 //silently catch 3 exceptions
                 getInfoException = e;
             }
+        }
+        if (tState.equals(TaskInfoState.success) || tState.equals(TaskInfoState.error)) {
+            break;
+        }
+        if (deadlineNanos > 0L && System.nanoTime() >= deadlineNanos) {
+            throw new TimeoutException("Task did not complete within " + maxWaitMillis + "ms; last state was " + tState);
         }
         // sleep for a specified time based on task state.
         if (tState.equals(TaskInfoState.running)) {

--- a/src/test/java/com/vmware/vim25/mo/TaskTest.java
+++ b/src/test/java/com/vmware/vim25/mo/TaskTest.java
@@ -75,7 +75,7 @@ public class TaskTest {
         assertEquals("success", task.waitForTask(10, 10, 5000L));
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void waitForTask_withTimeout_throwsTimeoutWhenTaskNeverCompletes() throws Exception {
         Task task = taskReturning(TaskInfoState.running);
         long start = System.currentTimeMillis();
@@ -95,7 +95,7 @@ public class TaskTest {
         assertEquals("success", task.waitForTask(0, 0, 0L));
     }
 
-    @Test
+    @Test(timeout = 5000)
     public void waitForTask_singleArgTimeoutOverload_throwsTimeout() throws Exception {
         Task task = taskReturning(TaskInfoState.running);
         try {

--- a/src/test/java/com/vmware/vim25/mo/TaskTest.java
+++ b/src/test/java/com/vmware/vim25/mo/TaskTest.java
@@ -5,9 +5,11 @@ import com.vmware.vim25.TaskInfoState;
 import org.junit.Test;
 
 import java.rmi.RemoteException;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TaskTest {
 
@@ -17,6 +19,21 @@ public class TaskTest {
         return new Task(null, null) {
             @Override
             public TaskInfo getTaskInfo() throws RemoteException {
+                return info;
+            }
+        };
+    }
+
+    // Returns each state from the sequence on successive calls; once exhausted, sticks on the last value.
+    private static Task taskReturning(final TaskInfoState... sequence) {
+        return new Task(null, null) {
+            private int idx = 0;
+
+            @Override
+            public TaskInfo getTaskInfo() throws RemoteException {
+                TaskInfo info = new TaskInfo();
+                info.setState(idx < sequence.length ? sequence[idx] : sequence[sequence.length - 1]);
+                idx++;
                 return info;
             }
         };
@@ -50,5 +67,42 @@ public class TaskTest {
         task.waitForTask(5000, 5000);
         long elapsed = System.currentTimeMillis() - start;
         assertTrue("waitForTask slept after task failed; elapsed=" + elapsed + "ms", elapsed < 1000);
+    }
+
+    @Test
+    public void waitForTask_withTimeout_returnsSuccessWhenTaskCompletesInTime() throws Exception {
+        Task task = taskReturning(TaskInfoState.running, TaskInfoState.success);
+        assertEquals("success", task.waitForTask(10, 10, 5000L));
+    }
+
+    @Test
+    public void waitForTask_withTimeout_throwsTimeoutWhenTaskNeverCompletes() throws Exception {
+        Task task = taskReturning(TaskInfoState.running);
+        long start = System.currentTimeMillis();
+        try {
+            task.waitForTask(50, 50, 200L);
+            fail("Expected TimeoutException when task stays running past the deadline");
+        } catch (TimeoutException expected) {
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue("timed out too late; elapsed=" + elapsed + "ms", elapsed < 1000);
+            assertTrue("timeout message should mention the limit", expected.getMessage().contains("200"));
+        }
+    }
+
+    @Test
+    public void waitForTask_zeroTimeout_meansNoTimeout() throws Exception {
+        Task task = taskReturning(TaskInfoState.success);
+        assertEquals("success", task.waitForTask(0, 0, 0L));
+    }
+
+    @Test
+    public void waitForTask_singleArgTimeoutOverload_throwsTimeout() throws Exception {
+        Task task = taskReturning(TaskInfoState.running);
+        try {
+            task.waitForTask(100L);
+            fail("Expected TimeoutException");
+        } catch (TimeoutException expected) {
+            // expected
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds two new overloads on `Task.waitForTask` that accept a `maxWaitMillis` deadline:
  - `waitForTask(long maxWaitMillis)` — uses default 500ms/1000ms poll intervals
  - `waitForTask(int runningDelay, int queuedDelay, long maxWaitMillis)` — full control
- When the deadline passes before the task reaches a terminal state, throws `java.util.concurrent.TimeoutException`. The task itself is **not** cancelled — callers can call `cancelTask()` if they want.
- A `maxWaitMillis <= 0` value means "wait forever", preserving the existing behavior of the parameter-less overloads. Both pre-existing overloads delegate to the new method with `0L`, so no caller behavior changes.
- Closes #238

## Why

Per the issue: a vSphere task can stay in `running` state for a long time (the reporter saw nearly an hour for a `PowerOffVM_Task` after a host hardware failure). `waitForTask` previously had no upper bound, which is fine for batch use but pathological for callers like the Jenkins vSphere plugin that hold locks while waiting.

## Test plan

- [x] All existing `TaskTest` cases pass unchanged
- [x] New test: `waitForTask_withTimeout_returnsSuccessWhenTaskCompletesInTime` — verifies normal completion within the deadline
- [x] New test: `waitForTask_withTimeout_throwsTimeoutWhenTaskNeverCompletes` — verifies the deadline triggers `TimeoutException` and the elapsed time is bounded
- [x] New test: `waitForTask_zeroTimeout_meansNoTimeout` — verifies `0L` preserves the no-timeout contract
- [x] New test: `waitForTask_singleArgTimeoutOverload_throwsTimeout` — covers the convenience overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)