### PR TITLE
fix(mo): fail fast on invalid session string in ServiceInstance (#331)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
+++ b/src/main/java/com/vmware/vim25/mo/ServiceInstance.java
@@ -81,6 +81,9 @@ public class ServiceInstance extends ManagedObject {
     //with new SOAP_ACTION
     serviceContent = retrieveServiceContent(vimService, SERVICE_INSTANCE_MOR);
     UserSession userSession = getCurrentUserSession();
+    if (userSession == null) {
+        throw new RemoteException("Session string is invalid or expired — vCenter returned no current session for the supplied cookie.");
+    }
     getServerConnection().setUserSession(userSession);
 }
     protected UserSession getCurrentUserSession() {

--- a/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ServiceInstanceTest.java
@@ -328,6 +328,31 @@ public class ServiceInstanceTest {
     }
 
     @Test
+    public void sessionStringConstructor_throwsWhenSessionInvalid() throws Exception {
+        try {
+            new ServiceInstance(new URL("https://some-vcenter-address/sdk"), "vmware_soap_session=\"bogus\"", true) {
+                @Override
+                protected UserSession getCurrentUserSession() {
+                    return null;  // simulate the server saying "no current session for that cookie"
+                }
+                @Override
+                protected ServiceContent retrieveServiceContent(VimPortType vimService, ManagedObjectReference mor) {
+                    return new ServiceContent();
+                }
+                @Override
+                protected String getApiVersion(ServiceContent serviceContent) {
+                    return "7.0";
+                }
+            };
+            Assert.fail("Expected RemoteException when session string is invalid");
+        } catch (RemoteException expected) {
+            Assert.assertTrue("message should mention session: " + expected.getMessage(),
+                expected.getMessage() != null
+                && expected.getMessage().toLowerCase().contains("session"));
+        }
+    }
+
+    @Test
     public void testExistingConstructorPassesNullLocale() {
         try {
             TestServiceInstance si = new TestServiceInstance(new URL("https://some-vcenter-address/sdk"), "username", "password", true, ServiceInstance.VIM25_NAMESPACE, 2000, 5000);


### PR DESCRIPTION
## Summary

When constructing a `ServiceInstance` from a session string, an invalid or expired session previously caused `getCurrentUserSession()` to return `null`, which was silently stored on the `ServerConnection`. The failure surfaced downstream as an NPE somewhere in user code — far from the actual cause.

This change throws `RemoteException` with a clear message at construction time, so the failure happens where it originates.

Closes #331.

## Approach (TDD)

1. Wrote the test first — anonymous `ServiceInstance` subclass that overrides `getCurrentUserSession()` to return `null`, asserts construction throws `RemoteException` with a "session"-ish message.
2. Ran the test against the unfixed constructor — it failed with `AssertionError: Expected RemoteException when session string is invalid` because the constructor silently succeeded.
3. Added the null check + `throw new RemoteException(...)` in `constructServiceInstance`.
4. Re-ran the test — passes.
5. All 22 existing `ServiceInstanceTest` cases plus the new test all pass.

## Behavior change

- Callers that previously got back a "valid-looking" `ServiceInstance` and then NPEd later will now get a clear `RemoteException` at construction. This is strictly better diagnostically.
- Username/password constructors are unaffected — `login()` already throws on bad credentials.

## Test plan

- [x] New test verifies the constructor throws `RemoteException` with a session-mentioning message when the session is invalid
- [x] All existing `ServiceInstanceTest` cases pass unchanged (22 total)
- [x] Confirmed the test fails against the prior implementation (assertion error rather than NPE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)