### PR TITLE
feat(mo): expose InventoryNavigator.retrieveObjectContents (#279)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
+++ b/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
@@ -57,7 +57,23 @@ public class InventoryNavigator {
         return createManagedEntities(ocs);
     }
 
-    private ObjectContent[] retrieveObjectContents(String[][] typeinfo, boolean recurse) throws InvalidProperty, RuntimeFault, RemoteException {
+    /**
+     * Retrieve raw {@link ObjectContent} for entities matching {@code typeinfo}, optionally recursing
+     * down from the root entity. Use this when you need the entities <em>and</em> their requested
+     * property values from a single round-trip — {@link #searchManagedEntities(String[][], boolean)}
+     * throws the property values away.
+     *
+     * Each returned {@link ObjectContent} carries the entity's MOR (use
+     * {@link com.vmware.vim25.mo.util.MorUtil#createExactManagedEntity} to wrap it) plus a
+     * {@code propSet} with the requested property values. Note that ManagedEntity instances
+     * created from these MORs do not cache the values — calling getters on them still triggers
+     * a server round-trip. Read property values from the {@code propSet} directly.
+     *
+     * @param typeinfo 2D array of {typename, prop1, prop2, ...} per type; null/empty returns null
+     * @param recurse  retrieve contents recursively from the root down
+     * @return ObjectContent for each matching entity, or null when typeinfo is null/empty
+     */
+    public ObjectContent[] retrieveObjectContents(String[][] typeinfo, boolean recurse) throws InvalidProperty, RuntimeFault, RemoteException {
         if (typeinfo == null || typeinfo.length == 0) {
             return null;
         }

--- a/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
+++ b/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
@@ -134,4 +134,50 @@ public class InventoryNavigatorTest {
         assertNotNull(result);
         assertEquals(0, result.length);
     }
+
+    private ObjectContent folderContentWithProps(String val, String name, String overallStatus) {
+        ObjectContent oc = folderContent(val);
+        DynamicProperty pName = new DynamicProperty();
+        pName.setName("name");
+        pName.setVal(name);
+        DynamicProperty pStatus = new DynamicProperty();
+        pStatus.setName("overallStatus");
+        pStatus.setVal(overallStatus);
+        oc.setPropSet(new DynamicProperty[]{pName, pStatus});
+        return oc;
+    }
+
+    @Test
+    public void retrieveObjectContents_isPublic_andPreservesPropSet() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector(
+            page(null,
+                folderContentWithProps("folder-1", "datacenter-folder", "green"),
+                folderContentWithProps("folder-2", "vm-folder", "yellow"))
+        );
+        InventoryNavigator nav = makeNavigator(stubPc);
+
+        ObjectContent[] result = nav.retrieveObjectContents(
+            new String[][]{{"Folder", "name", "overallStatus"}}, true);
+
+        assertEquals(2, result.length);
+
+        DynamicProperty[] firstProps = result[0].getPropSet();
+        assertEquals(2, firstProps.length);
+        assertEquals("name", firstProps[0].getName());
+        assertEquals("datacenter-folder", firstProps[0].getVal());
+        assertEquals("overallStatus", firstProps[1].getName());
+        assertEquals("green", firstProps[1].getVal());
+
+        assertEquals("folder-2", result[1].getObj().getVal());
+        assertEquals("vm-folder", result[1].getPropSet()[0].getVal());
+    }
+
+    @Test
+    public void retrieveObjectContents_nullTypeinfo_returnsNull() throws Exception {
+        InventoryNavigator nav = makeNavigator(new StubPropertyCollector());
+
+        ObjectContent[] result = nav.retrieveObjectContents(null, true);
+
+        assertNull(result);
+    }
 }


### PR DESCRIPTION
## Summary

`InventoryNavigator.searchManagedEntities(String[][] typeinfo, boolean recurse)` *internally* fetches `ObjectContent[]` containing both the entity MORs and the requested property values — then throws the property values away and returns just `ManagedEntity[]`. Callers who want properties have to make a second round-trip via `PropertyCollectorUtil.retrieveProperties`, exactly the kind of double-call the typeinfo argument was designed to avoid.

This change makes `retrieveObjectContents(String[][], boolean)` public so callers can get both entities and properties from a single round-trip:

```java
ObjectContent[] ocs = nav.retrieveObjectContents(
    new String[][]{{"VirtualMachine", "name", "runtime"}}, true);
for (ObjectContent oc : ocs) {
    VirtualMachine vm = (VirtualMachine) MorUtil.createExactManagedEntity(connection, oc.getObj());
    for (DynamicProperty p : oc.getPropSet()) {
        // "name" and "runtime" already in hand
    }
}
```

The Javadoc explicitly notes that ManagedEntity instances built from these MORs don't cache the property values — callers should read from `propSet` directly. Adding a property cache to `ManagedEntity` would be a much larger surgery and is out of scope here.

Closes #279.

## Approach (TDD)

1. Wrote two new tests against the desired public API — one verifying the propSet flows through populated, one verifying the null-typeinfo guard.
2. Compiled — failed with `error: retrieveObjectContents(String[][],boolean) has private access`.
3. Changed the method's modifier from `private` to `public` and added a Javadoc block.
4. Re-ran — all 6 InventoryNavigatorTest cases pass.

## Test plan

- [x] All existing InventoryNavigator tests still pass (4 originals + 2 new = 6 total)
- [x] New test `retrieveObjectContents_isPublic_andPreservesPropSet` verifies entity MOR + propSet both come through
- [x] New test `retrieveObjectContents_nullTypeinfo_returnsNull` documents the null-typeinfo contract
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)