### PR TITLE
feat(mo): cached property reads via searchManagedEntitiesWithProperties (#279)

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
+++ b/src/main/java/com/vmware/vim25/mo/InventoryNavigator.java
@@ -10,6 +10,18 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Locate ManagedEntity objects under a root folder. Supports two modes:
+ *
+ * <ul>
+ *   <li>Find-only ({@link #searchManagedEntities(String)} and friends) — returns entities
+ *       whose subsequent property reads round-trip to the server.</li>
+ *   <li>Find-and-fetch ({@link #searchManagedEntitiesWithProperties(String[][], boolean)}) —
+ *       single round-trip that returns entities with the requested properties pre-cached;
+ *       subsequent reads of those properties via typed getters are served from the cache.</li>
+ * </ul>
+ */
+
 public class InventoryNavigator {
     private ManagedEntity rootEntity = null;
     private SelectionSpec[] selectionSpecs = null;
@@ -42,19 +54,58 @@ public class InventoryNavigator {
     }
 
     /**
-     * Retrieve content recursively with multiple properties.
-     * the typeinfo array contains typename + properties to retrieve.
+     * Retrieve content recursively with multiple properties. The {@code typeinfo} array contains
+     * {typename, prop1, prop2, ...} per type.
+     *
+     * <p><strong>Note:</strong> the requested property values are fetched from the server but
+     * <em>discarded</em> — only the entities are returned, and subsequent calls to entity getters
+     * round-trip to the server again. To keep the property values, use
+     * {@link #searchManagedEntitiesWithProperties(String[][], boolean)} instead.
      *
      * @param typeinfo 2D array of properties for each typename
      * @param recurse  retrieve contents recursively from the root down
-     * @return retrieved object contents
-     * @throws RemoteException
-     * @throws RuntimeFault
-     * @throws InvalidProperty
+     * @return matching entities (without cached properties)
      */
     public ManagedEntity[] searchManagedEntities(String[][] typeinfo, boolean recurse) throws InvalidProperty, RuntimeFault, RemoteException {
         ObjectContent[] ocs = retrieveObjectContents(typeinfo, recurse);
         return createManagedEntities(ocs);
+    }
+
+    /**
+     * Like {@link #searchManagedEntities(String[][], boolean)} but pre-populates each returned
+     * entity's property cache with the requested values. Reading a cached property via the
+     * entity's typed getter (e.g. {@code vm.getName()}) returns the cached value without
+     * contacting the server. Reads of properties that weren't requested fall through to the
+     * server as usual.
+     *
+     * <p>Cached values do not refresh — long-lived entities will return stale data if the
+     * underlying property changes on the server. For polling use cases, re-run the search.
+     *
+     * <p>Single round-trip equivalent of:
+     * <pre>
+     * ManagedEntity[] mes = nav.searchManagedEntities(typename);
+     * Hashtable&lt;String, Object&gt;[] props = PropertyCollectorUtil.retrieveProperties(mes, typename, propNames);
+     * </pre>
+     *
+     * @param typeinfo 2D array of {typename, prop1, prop2, ...} per type
+     * @param recurse  retrieve contents recursively from the root down
+     */
+    public ManagedEntity[] searchManagedEntitiesWithProperties(String[][] typeinfo, boolean recurse) throws InvalidProperty, RuntimeFault, RemoteException {
+        ObjectContent[] ocs = retrieveObjectContents(typeinfo, recurse);
+        if (ocs == null) {
+            return new ManagedEntity[]{};
+        }
+        ManagedEntity[] mes = new ManagedEntity[ocs.length];
+        for (int i = 0; i < mes.length; i++) {
+            mes[i] = MorUtil.createExactManagedEntity(rootEntity.getServerConnection(), ocs[i].getObj());
+            DynamicProperty[] propSet = ocs[i].getPropSet();
+            if (propSet != null) {
+                for (DynamicProperty p : propSet) {
+                    mes[i].setCachedProperty(p.getName(), p.getVal());
+                }
+            }
+        }
+        return mes;
     }
 
     private ObjectContent[] retrieveObjectContents(String[][] typeinfo, boolean recurse) throws InvalidProperty, RuntimeFault, RemoteException {

--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.rmi.RemoteException;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 /**
  * This class is intended to provide a wrapper around a managed object class.
@@ -70,6 +72,14 @@ abstract public class ManagedObject {
      * holds the ExtensionManager managed object reference
      */
     private ManagedObjectReference mor = null;
+
+    /**
+     * Optional cache of property values, populated by callers who pre-fetched a known set of
+     * properties (for example via {@link InventoryNavigator#searchManagedEntitiesWithProperties}).
+     * Null until the first {@link #setCachedProperty} call to keep the per-instance footprint at
+     * zero for callers that don't use the cache. Read by {@link #getCurrentProperty(String)}.
+     */
+    private Map<String, Object> cachedProperties = null;
 
     protected ManagedObject() {
     }
@@ -164,7 +174,27 @@ abstract public class ManagedObject {
      * ManagedObjectReference objects are data objects!!!
      */
 
+    /**
+     * Pre-populate this object's property cache with a value the caller already fetched
+     * (for example, from an InventoryNavigator bulk read). A subsequent
+     * {@link #getCurrentProperty(String)} for the same name returns the cached value
+     * without contacting the server.
+     *
+     * The cache is opt-in: callers who never call this method incur no overhead and
+     * see the original always-round-trip behavior. Cached values do not expire — long-lived
+     * entities will return stale data if the underlying property changes on the server.
+     */
+    public void setCachedProperty(String propertyName, Object value) {
+        if (cachedProperties == null) {
+            cachedProperties = new HashMap<String, Object>();
+        }
+        cachedProperties.put(propertyName, value);
+    }
+
     protected Object getCurrentProperty(String propertyName) {
+        if (cachedProperties != null && cachedProperties.containsKey(propertyName)) {
+            return cachedProperties.get(propertyName);
+        }
         ObjectContent objContent = retrieveObjectProperties(new String[]{propertyName});
 
         Object propertyValue = null;

--- a/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
+++ b/src/test/java/com/vmware/vim25/mo/InventoryNavigatorTest.java
@@ -134,4 +134,49 @@ public class InventoryNavigatorTest {
         assertNotNull(result);
         assertEquals(0, result.length);
     }
+
+    private ObjectContent folderContentWithProps(String val, String name, ManagedEntityStatus overallStatus) {
+        ObjectContent oc = folderContent(val);
+        DynamicProperty pName = new DynamicProperty();
+        pName.setName("name");
+        pName.setVal(name);
+        DynamicProperty pStatus = new DynamicProperty();
+        pStatus.setName("overallStatus");
+        pStatus.setVal(overallStatus);
+        oc.setPropSet(new DynamicProperty[]{pName, pStatus});
+        return oc;
+    }
+
+    @Test
+    public void searchManagedEntitiesWithProperties_populatesPropertyCacheOnEachEntity() throws Exception {
+        StubPropertyCollector stubPc = new StubPropertyCollector(
+            page(null,
+                folderContentWithProps("folder-1", "datacenter-folder", ManagedEntityStatus.green),
+                folderContentWithProps("folder-2", "vm-folder", ManagedEntityStatus.yellow))
+        );
+        InventoryNavigator nav = makeNavigator(stubPc);
+
+        ManagedEntity[] result = nav.searchManagedEntitiesWithProperties(
+            new String[][]{{"Folder", "name", "overallStatus"}}, true);
+
+        assertEquals(2, result.length);
+
+        // Cached values are accessible via the typed getters with no extra round-trip.
+        // Calling getName() here would NPE if it tried to talk to the server (stub is
+        // PropertyCollector-only and getName() goes through getCurrentProperty/retrieveObjectProperties).
+        assertEquals("datacenter-folder", result[0].getName());
+        assertEquals(ManagedEntityStatus.green, result[0].getOverallStatus());
+        assertEquals("vm-folder", result[1].getName());
+        assertEquals(ManagedEntityStatus.yellow, result[1].getOverallStatus());
+    }
+
+    @Test
+    public void searchManagedEntitiesWithProperties_nullTypeinfo_returnsEmptyArray() throws Exception {
+        InventoryNavigator nav = makeNavigator(new StubPropertyCollector());
+
+        ManagedEntity[] result = nav.searchManagedEntitiesWithProperties(null, true);
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
 }

--- a/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
@@ -81,6 +81,37 @@ public class ManagedObjectCurrentPropertyTest {
         }
     }
 
+    // Subclass that fails loudly if retrieveObjectProperties is called — proves the cache short-circuits the server call.
+    static class CacheOnlyManagedObject extends ManagedObject {
+        @Override
+        protected ObjectContent retrieveObjectProperties(String[] properties) {
+            throw new AssertionError("retrieveObjectProperties called for "
+                + (properties != null && properties.length > 0 ? properties[0] : "?")
+                + " — cache should have served this read");
+        }
+        public Object testGetCurrentProperty(String name) {
+            return getCurrentProperty(name);
+        }
+    }
+
+    @Test
+    public void getCurrentProperty_returnsCachedValue_withoutServerCall() {
+        CacheOnlyManagedObject mo = new CacheOnlyManagedObject();
+        mo.setCachedProperty("name", "test-vm");
+        mo.setCachedProperty("overallStatus", "green");
+
+        assertEquals("test-vm", mo.testGetCurrentProperty("name"));
+        assertEquals("green", mo.testGetCurrentProperty("overallStatus"));
+    }
+
+    @Test
+    public void getCurrentProperty_cachedNullValue_returnsNullWithoutServerCall() {
+        CacheOnlyManagedObject mo = new CacheOnlyManagedObject();
+        mo.setCachedProperty("network", null);  // server may legitimately return null for a property
+
+        assertNull(mo.testGetCurrentProperty("network"));
+    }
+
     @Test
     public void getCurrentProperty_runtimeExceptionMessageIsLocalizedMessageFromFault() {
         MissingProperty missing = new MissingProperty();


### PR DESCRIPTION
## Summary

Closes #279. Replaces the previous PR #334 with a design that resolves all three of the reporter's pain points without contradicting #233.

The reporter wanted to fetch entities + properties in one round-trip *and* read the values via the natural typed getters (`vm.getName()`, `vm.getRuntime()`) instead of casting out of `Hashtable<String, Object>[]`. Just exposing `retrieveObjectContents` (the previous attempt) only solved the round-trip and contradicted what we said in #233.

## What changed

**`ManagedObject` — opt-in property cache**
- New private field `Map<String, Object> cachedProperties`, lazily allocated only when used (zero overhead for callers who don't opt in).
- New public `setCachedProperty(String, Object)` to populate the cache.
- `getCurrentProperty(String)` now checks the cache first; on hit, returns the cached value without a server call. On miss, falls through to the existing `retrieveObjectProperties` path — so existing behavior is unchanged for any caller who hasn't populated the cache.

**`InventoryNavigator` — new `searchManagedEntitiesWithProperties` method**
- Same shape as `searchManagedEntities(String[][], boolean)` but pre-populates each returned entity's cache from the `propSet` returned by the property collector.
- The internal helper `retrieveObjectContents` stays private — #233 still holds.
- The existing `searchManagedEntities(String[][], boolean)` is documented as discarding the property values, with a pointer at the new method.

**Caller experience:**

```java
ManagedEntity[] mes = nav.searchManagedEntitiesWithProperties(
    new String[][]{{"VirtualMachine", "name", "runtime"}}, true);
for (ManagedEntity me : mes) {
    VirtualMachine vm = (VirtualMachine) me;
    String name = vm.getName();             // cache hit, no round-trip
    VirtualMachineRuntimeInfo r = vm.getRuntime();  // cache hit, no round-trip
}
```

vs. the previous workaround which needed `searchManagedEntities` + a separate `PropertyCollectorUtil.retrieveProperties` call and ugly `Hashtable<String, Object>[]` access.

## Trade-offs noted in Javadoc

- The cache doesn't refresh. Long-lived entities will return stale values if the underlying property changes on the server. For polling, re-run the search.
- Properties not requested still round-trip on read (cache miss → server call). That's intentional — only the bulk-fetched properties are cached.

## TDD walkthrough

1. Wrote `getCurrentProperty_returnsCachedValue_withoutServerCall` and `getCurrentProperty_cachedNullValue_returnsNullWithoutServerCall` — used a `CacheOnlyManagedObject` subclass whose `retrieveObjectProperties` throws `AssertionError`, proving the cache short-circuits the server call entirely.
2. Compile fail (`setCachedProperty` doesn't exist) → added the cache field/method/lookup → tests pass.
3. Wrote `searchManagedEntitiesWithProperties_populatesPropertyCacheOnEachEntity` and `searchManagedEntitiesWithProperties_nullTypeinfo_returnsEmptyArray` against the desired API.
4. Compile fail (`searchManagedEntitiesWithProperties` doesn't exist) → implemented it → tests pass.
5. Verified the regression-catching property: gutted the `setCachedProperty` calls in the new method; the cache test failed (entities fell through to the server stub which returned wrong-typed values, producing CCE — different exception class than ideal but still catches the regression).

## Test plan

- [x] `ManagedObjectCurrentPropertyTest` — 7 tests pass (5 existing + 2 new cache tests)
- [x] `InventoryNavigatorTest` — 6 tests pass (4 existing + 2 new for the bulk-fetch method)
- [x] Full test suite passes
- [x] Cache is null/lazy by default, so all existing call sites that don't use the new method see no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)