### PR TITLE
test(xml): regression coverage for #228 (Tag[]/AlarmState[] via DynamicProperty.val)

### DIFF
--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -194,6 +194,40 @@ public class XmlGenDomTest {
     }
 
     @Test
+    public void testFromXML_TagArrayProperty_DeserializesAsTagArray() throws Exception {
+        // Issue #228: ManagedEntity.tag (Tag[]) and triggeredAlarmState (AlarmState[])
+        // came back as raw java.lang.Object via DynamicProperty.val. The XML in the
+        // wild uses xsi:type="ArrayOfTag" / "ArrayOfAlarmState" wrappers around the items.
+        InputStream inputStream = new FileInputStream(
+            new File("src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithTagAndAlarmState.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        ObjectContent objectContent = (ObjectContent) xmlGenDom.fromXML("ObjectContent", inputStream);
+
+        Assert.assertNotNull(objectContent.getPropSet());
+        Assert.assertEquals(2, objectContent.getPropSet().length);
+
+        Object tagVal = objectContent.getPropSet()[0].getVal();
+        Assert.assertNotNull("tag value should not be null", tagVal);
+        Assert.assertTrue(
+            "tag value should be Tag[], got " + tagVal.getClass().getName(),
+            tagVal instanceof Tag[]);
+        Tag[] tags = (Tag[]) tagVal;
+        Assert.assertEquals(2, tags.length);
+        Assert.assertEquals("com.vmware.cis.tagging.Tag:abcd-1234", tags[0].getKey());
+        Assert.assertEquals("com.vmware.cis.tagging.Tag:efgh-5678", tags[1].getKey());
+
+        Object alarmVal = objectContent.getPropSet()[1].getVal();
+        Assert.assertNotNull("triggeredAlarmState value should not be null", alarmVal);
+        Assert.assertTrue(
+            "triggeredAlarmState value should be AlarmState[], got " + alarmVal.getClass().getName(),
+            alarmVal instanceof AlarmState[]);
+        AlarmState[] states = (AlarmState[]) alarmVal;
+        Assert.assertEquals(1, states.length);
+        Assert.assertEquals("alarm-1.vm-42", states[0].getKey());
+        Assert.assertEquals(ManagedEntityStatus.red, states[0].getOverallStatus());
+    }
+
+    @Test
     public void testFromXML_PerfCounterInfoWithUnknownSubtype_ParsesGracefully() throws Exception {
         InputStream inputStream = new FileInputStream(
             new File("src/test/java/com/vmware/vim25/ws/xml/PerfCounterInfoWithUnknownSubtype.xml"));

--- a/src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithTagAndAlarmState.xml
+++ b/src/test/java/com/vmware/vim25/ws/xml/ObjectContentWithTagAndAlarmState.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <RetrievePropertiesResponse xmlns="urn:vim25">
+            <returnval>
+                <obj type="VirtualMachine">vm-42</obj>
+                <propSet>
+                    <name>tag</name>
+                    <val xsi:type="ArrayOfTag">
+                        <Tag xsi:type="Tag">
+                            <key>com.vmware.cis.tagging.Tag:abcd-1234</key>
+                        </Tag>
+                        <Tag xsi:type="Tag">
+                            <key>com.vmware.cis.tagging.Tag:efgh-5678</key>
+                        </Tag>
+                    </val>
+                </propSet>
+                <propSet>
+                    <name>triggeredAlarmState</name>
+                    <val xsi:type="ArrayOfAlarmState">
+                        <AlarmState xsi:type="AlarmState">
+                            <key>alarm-1.vm-42</key>
+                            <entity type="VirtualMachine">vm-42</entity>
+                            <alarm type="Alarm">alarm-1</alarm>
+                            <overallStatus>red</overallStatus>
+                            <time>2026-01-15T10:30:00Z</time>
+                            <acknowledged>false</acknowledged>
+                        </AlarmState>
+                    </val>
+                </propSet>
+            </returnval>
+        </RetrievePropertiesResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
## Summary

- Adds a regression test showing `DynamicProperty.val` with `xsi:type="ArrayOfTag"` and `xsi:type="ArrayOfAlarmState"` deserializes to the typed array (`Tag[]`, `AlarmState[]`), not the wrapper class.
- New XML fixture `ObjectContentWithTagAndAlarmState.xml` shaped like a real `RetrievePropertiesResponse` for `VirtualMachine.tag` + `triggeredAlarmState`.

## Why this exists

Issue #228 (Mar 2017) reported that `tag` and `triggeredAlarmState` came back as `java.lang.Object@hash`. Tracing showed `DynamicProperty.val` was being populated with an `ArrayOf*` wrapper instance (e.g. `ArrayOfTag`), whose `toString()` is the default `Object.toString()` — hence the `Object@hash` string the reporter saw.

PR #320 (closes #156) fixed this by detecting `ArrayOf*` xsi:types upfront and parsing the element as a typed array. That fix also closes #228 — but no test was added covering the `Tag[]` / `AlarmState[]` path specifically. This PR adds that coverage.

## Verification

Verified red/green by temporarily reverting `XmlGenDom.java` to its pre-#320 state:

- **Pre-#320:** test fails with `tag value should be Tag[], got com.vmware.vim25.ArrayOfTag`
- **Current code:** test passes

## Test plan

- [x] New test passes against current `gradle` HEAD
- [x] New test fails against pre-#320 `XmlGenDom.java`
- [x] Full test suite still passes

Closes #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)