### PR TITLE
fix(cf): switch ManagedObjectWatcher to waitForUpdatesEx (#110)

### DIFF
--- a/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
+++ b/src/main/java/com/vmware/vim/cf/ManagedObjectWatcher.java
@@ -40,6 +40,7 @@ import com.vmware.vim25.PropertyFilterSpec;
 import com.vmware.vim25.PropertyFilterUpdate;
 import com.vmware.vim25.PropertySpec;
 import com.vmware.vim25.UpdateSet;
+import com.vmware.vim25.WaitOptions;
 import com.vmware.vim25.mo.ManagedObject;
 import com.vmware.vim25.mo.PropertyCollector;
 import com.vmware.vim25.mo.PropertyFilter;
@@ -118,11 +119,15 @@ class ManagedObjectWatcher implements Runnable {
      *
      */
     public void run() {
+        WaitOptions options = new WaitOptions();
         while (true) {
             try {
-                UpdateSet update = pc.waitForUpdates(version);
-                PropertyFilterUpdate[] pfu = update.getFilterSet();
-                notifyListeners(pfu);
+                UpdateSet update = pc.waitForUpdatesEx(version, options);
+                if (update == null) {
+                    // No updates within the wait window — server returns null per the SDK contract.
+                    continue;
+                }
+                notifyListeners(update.getFilterSet());
                 version = update.getVersion();
             }
             catch (NotAuthenticated na) {

--- a/src/test/java/com/vmware/vim/cf/ManagedObjectWatcherTest.java
+++ b/src/test/java/com/vmware/vim/cf/ManagedObjectWatcherTest.java
@@ -1,7 +1,12 @@
 package com.vmware.vim.cf;
 
-import com.vmware.vim25.PropertyFilterUpdate;
+import com.vmware.vim25.*;
+import com.vmware.vim25.mo.PropertyCollector;
 import org.junit.Test;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -53,5 +58,106 @@ public class ManagedObjectWatcherTest {
     public void notifyListeners_withNoListeners_doesNotThrow() {
         ManagedObjectWatcher watcher = new ManagedObjectWatcher(null);
         watcher.notifyListeners(new PropertyFilterUpdate[0]); // should not throw
+    }
+
+    // Recorded calls into a stub PropertyCollector.
+    static class StubPropertyCollector extends PropertyCollector {
+        int waitForUpdatesCalls = 0;
+        int waitForUpdatesExCalls = 0;
+        final List<String> waitForUpdatesExVersions = new ArrayList<>();
+        final List<UpdateSet> updateSetSequence = new ArrayList<>();
+        Throwable throwAfterSequence = null;
+
+        StubPropertyCollector() {
+            super(null, null);
+        }
+
+        @Override
+        public UpdateSet waitForUpdates(String version) {
+            waitForUpdatesCalls++;
+            return null;
+        }
+
+        @Override
+        public UpdateSet waitForUpdatesEx(String version, WaitOptions options) throws RuntimeFault, RemoteException {
+            int idx = waitForUpdatesExCalls;
+            waitForUpdatesExCalls++;
+            waitForUpdatesExVersions.add(version);
+            if (idx < updateSetSequence.size()) {
+                return updateSetSequence.get(idx);
+            }
+            if (throwAfterSequence != null) {
+                if (throwAfterSequence instanceof RuntimeException) throw (RuntimeException) throwAfterSequence;
+                if (throwAfterSequence instanceof RemoteException) throw (RemoteException) throwAfterSequence;
+                throw new RuntimeException(throwAfterSequence);
+            }
+            // Default: signal end of test by throwing NotAuthenticated which the loop treats as exit.
+            throw new NotAuthenticated();
+        }
+    }
+
+    private UpdateSet updateSetWithVersion(String version, PropertyFilterUpdate... filterSet) {
+        UpdateSet us = new UpdateSet();
+        us.setVersion(version);
+        us.setFilterSet(filterSet);
+        return us;
+    }
+
+    @Test(timeout = 5000)
+    public void run_usesWaitForUpdatesEx_notDeprecatedWaitForUpdates() {
+        // Issue #110: deprecated waitForUpdates returns null on vCenter 6+, then update.getFilterSet() NPEs.
+        // Watcher must call the supported waitForUpdatesEx instead.
+        StubPropertyCollector pc = new StubPropertyCollector();
+        // First call returns one UpdateSet, second call throws NotAuthenticated to break the loop.
+        pc.updateSetSequence.add(updateSetWithVersion("v1", new PropertyFilterUpdate()));
+
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(pc);
+        watcher.run();
+
+        assertEquals("waitForUpdates (deprecated) must not be called", 0, pc.waitForUpdatesCalls);
+        assertTrue("waitForUpdatesEx must be called at least once", pc.waitForUpdatesExCalls >= 1);
+    }
+
+    @Test(timeout = 5000)
+    public void run_nullUpdateSet_doesNotNPE_advancesPastEmptyResponse() {
+        // waitForUpdatesEx legitimately returns null when the wait window expires with no updates.
+        // The loop must skip the iteration without dereferencing.
+        StubPropertyCollector pc = new StubPropertyCollector();
+        pc.updateSetSequence.add(null);
+        pc.updateSetSequence.add(updateSetWithVersion("v1", new PropertyFilterUpdate()));
+
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(pc);
+        int[] notifications = {0};
+        watcher.addListener(updates -> notifications[0]++);
+
+        watcher.run();
+
+        // First call returned null and was skipped. Second returned a real UpdateSet and notified once.
+        // Third call throws NotAuthenticated to exit.
+        assertEquals(1, notifications[0]);
+        assertEquals(3, pc.waitForUpdatesExCalls);
+    }
+
+    @Test(timeout = 5000)
+    public void run_validUpdateSet_notifiesListenersAndAdvancesVersion() {
+        StubPropertyCollector pc = new StubPropertyCollector();
+        PropertyFilterUpdate u1 = new PropertyFilterUpdate();
+        PropertyFilterUpdate u2 = new PropertyFilterUpdate();
+        pc.updateSetSequence.add(updateSetWithVersion("v1", u1));
+        pc.updateSetSequence.add(updateSetWithVersion("v2", u2));
+
+        ManagedObjectWatcher watcher = new ManagedObjectWatcher(pc);
+        List<PropertyFilterUpdate[]> received = new ArrayList<>();
+        watcher.addListener(received::add);
+
+        watcher.run();
+
+        assertEquals(2, received.size());
+        assertSame(u1, received.get(0)[0]);
+        assertSame(u2, received.get(1)[0]);
+        // Version advances: first call sees "", second sees "v1", third sees "v2".
+        assertEquals("", pc.waitForUpdatesExVersions.get(0));
+        assertEquals("v1", pc.waitForUpdatesExVersions.get(1));
+        assertEquals("v2", pc.waitForUpdatesExVersions.get(2));
     }
 }


### PR DESCRIPTION
## Summary

`CacheInstance.get()` returned null because the watcher thread crashed on its first iteration:

1. `pc.waitForUpdates(version)` is deprecated as of SDK 4.1; on vCenter 6+ the response deserializes to a `null` `UpdateSet`.
2. `update.getFilterSet()` then NPE'd.
3. The `catch (Exception e)` block caught it, logged, and re-entered the loop — spinning forever, never populating the cache.

## Changes

`ManagedObjectWatcher.run()`:
- Call the supported `pc.waitForUpdatesEx(version, options)` instead of the deprecated `waitForUpdates(version)`.
- When `waitForUpdatesEx` returns `null` (legitimate "wait window expired with no updates" signal), skip the iteration cleanly without dereferencing.

## Verification (TDD)

Added 3 stubbed `PropertyCollector` tests, all bounded by `@Test(timeout=5000)`:

1. `run_usesWaitForUpdatesEx_notDeprecatedWaitForUpdates` — counts calls to each method.
2. `run_nullUpdateSet_doesNotNPE_advancesPastEmptyResponse` — null first, real `UpdateSet` second; verifies one notification, three iterations.
3. `run_validUpdateSet_notifiesListenersAndAdvancesVersion` — verifies the version cursor advances `"" → "v1" → "v2"`.

All three tests fail against the pre-fix code (they timeout from the infinite NPE loop) and pass against the fix. Existing 4 tests still pass.

## What this does NOT address

Out of scope, called out for future tracking:

- **Shutdown ordering footgun** (yashu2203's 2019 comment): callers must invoke `cacheInstance.destroy()` before `serviceInstance.disconnect()`, otherwise the watcher thread sees `NotAuthenticated` after teardown. Worth documenting on `CacheInstance` separately.
- **Race between `start()` and `get()`**: tests that immediately call `get()` after `start()` see null because the cache hasn't populated yet. `isReady()` exists for polling; an explicit `awaitReady(timeoutMs)` helper would be friendlier but is a separate enhancement.

## Test plan

- [x] New tests fail against pre-fix code (verified during TDD)
- [x] New tests pass with fix
- [x] Full test suite passes

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)