### PR TITLE
fix(ws): set per-connection HostnameVerifier when ignoreCert=true (#115)

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
+++ b/src/main/java/com/vmware/vim25/ws/TrustAllSSL.java
@@ -27,6 +27,24 @@ public class TrustAllSSL {
     private static boolean alreadyCreated = false;
     private static SSLContext sslContext;
 
+    private static final HostnameVerifier TRUST_ALL_HOSTNAME_VERIFIER = new HostnameVerifier() {
+        public boolean verify(String urlHostName, SSLSession session) {
+            return true;
+        }
+    };
+
+    /**
+     * Returns a {@link HostnameVerifier} that accepts any hostname. Used by {@code WSClient}
+     * to disable hostname verification on each per-connection {@code HttpsURLConnection} when
+     * the caller opted into ignoring certificates. This is a per-connection setting; relying on
+     * {@link HttpsURLConnection#setDefaultHostnameVerifier(HostnameVerifier)} alone has timing
+     * pitfalls (issue #115: connections via IP rejected because the captured default fired
+     * before the trust-all default was installed).
+     */
+    public static HostnameVerifier getTrustAllHostnameVerifier() {
+        return TRUST_ALL_HOSTNAME_VERIFIER;
+    }
+
     public static synchronized SSLContext getTrustContext() throws RemoteException {
         try {
             if (getAlreadyCreated()) {

--- a/src/main/java/com/vmware/vim25/ws/WSClient.java
+++ b/src/main/java/com/vmware/vim25/ws/WSClient.java
@@ -34,6 +34,7 @@ package com.vmware.vim25.ws;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSocketFactory;
@@ -59,6 +60,7 @@ public class WSClient extends SoapClient {
 
     private static final Logger log = LoggerFactory.getLogger(WSClient.class);
     private final SSLSocketFactory sslSocketFactory;
+    private final HostnameVerifier hostnameVerifier;
 
     private XmlGen xmlGen = new XmlGenDom();
 
@@ -84,6 +86,11 @@ public class WSClient extends SoapClient {
         this.trustManager = trustManager;
         this.baseUrl = new URL(serverUrl);
         this.sslSocketFactory = ignoreCert ? getTrustAllSocketFactory(true) : getCustomTrustManagerSocketFactory(trustManager);
+        // ignoreCert means "don't verify the server's identity at all" — that includes
+        // the hostname check. Without this, IP-based connections fail with
+        // "No subject alternative names matching IP address …" because vSphere certs
+        // don't usually carry the IP in their SAN. See issue #115.
+        this.hostnameVerifier = ignoreCert ? TrustAllSSL.getTrustAllHostnameVerifier() : null;
     }
 
     public Object invoke(String methodName, Argument[] paras, String returnType) throws RemoteException {
@@ -132,8 +139,8 @@ public class WSClient extends SoapClient {
 
     protected InputStream post(String soapMsg) throws IOException {
         HttpURLConnection postCon = (HttpURLConnection) baseUrl.openConnection();
-        if (sslSocketFactory != null && baseUrl.getProtocol().equalsIgnoreCase("https")) {
-            ((HttpsURLConnection) postCon).setSSLSocketFactory(sslSocketFactory);
+        if (postCon instanceof HttpsURLConnection) {
+            applyHttpsConfig((HttpsURLConnection) postCon);
         }
 
         log.trace("POST: " + soapAction);
@@ -228,5 +235,14 @@ public class WSClient extends SoapClient {
 
     protected SSLSocketFactory getCustomTrustManagerSocketFactory(TrustManager tm) throws RemoteException {
         return tm != null ? CustomSSLTrustContextCreator.getTrustContext(tm).getSocketFactory() : null;
+    }
+
+    void applyHttpsConfig(HttpsURLConnection con) {
+        if (sslSocketFactory != null) {
+            con.setSSLSocketFactory(sslSocketFactory);
+        }
+        if (hostnameVerifier != null) {
+            con.setHostnameVerifier(hostnameVerifier);
+        }
     }
 }

--- a/src/test/java/com/vmware/vim25/ws/TrustAllSSLTest.java
+++ b/src/test/java/com/vmware/vim25/ws/TrustAllSSLTest.java
@@ -44,4 +44,18 @@ public class TrustAllSSLTest {
     public void trustAllHttpsCertificates_doesNotThrow() throws Exception {
         TrustAllSSL.trustAllHttpsCertificates();
     }
+
+    @Test
+    public void getTrustAllHostnameVerifier_returnsVerifierThatAcceptsAnyHostname() {
+        javax.net.ssl.HostnameVerifier verifier = TrustAllSSL.getTrustAllHostnameVerifier();
+        assertNotNull(verifier);
+        assertTrue(verifier.verify("any-host", null));
+        assertTrue(verifier.verify("192.0.2.1", null));
+    }
+
+    @Test
+    public void getTrustAllHostnameVerifier_returnsSameInstanceAcrossCalls() {
+        // Reused instance keeps WSClient.applyHttpsConfig allocation-free per request.
+        assertSame(TrustAllSSL.getTrustAllHostnameVerifier(), TrustAllSSL.getTrustAllHostnameVerifier());
+    }
 }

--- a/src/test/java/com/vmware/vim25/ws/WSClientTest.java
+++ b/src/test/java/com/vmware/vim25/ws/WSClientTest.java
@@ -4,10 +4,16 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.net.URL;
 import java.rmi.RemoteException;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
 
 import com.vmware.vim25.*;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class WSClientTest {
 
@@ -22,5 +28,40 @@ public class WSClientTest {
         }
         XmlGenDom xmlGenDom = new XmlGenDom();
         xmlGenDom.fromXML("Login", inputStream);
+    }
+
+    @Test
+    public void applyHttpsConfig_ignoreCertTrue_setsTrustAllHostnameVerifierOnConnection() throws Exception {
+        // Issue #115: when ignoreCert=true and the user connects by IP, the JDK default
+        // hostname verifier rejects the connection because the cert's SAN doesn't match
+        // the IP. Setting setDefaultHostnameVerifier globally inside TrustAllSSL is
+        // unreliable (timing of when the connection captures the default). The verifier
+        // must be set on each per-connection HttpsURLConnection.
+        WSClient client = new WSClient("https://192.0.2.1/sdk", true);
+        HttpsURLConnection con = (HttpsURLConnection) new URL("https://192.0.2.1/sdk").openConnection();
+
+        client.applyHttpsConfig(con);
+
+        HostnameVerifier verifier = con.getHostnameVerifier();
+        assertNotNull("hostname verifier should be set when ignoreCert=true", verifier);
+        assertTrue("trust-all verifier should accept any hostname",
+            verifier.verify("any-host", null));
+        assertTrue("trust-all verifier should accept IP address style hosts",
+            verifier.verify("192.0.2.1", null));
+        assertNotNull("ssl socket factory should be set", con.getSSLSocketFactory());
+    }
+
+    @Test
+    public void applyHttpsConfig_ignoreCertFalse_doesNotOverrideHostnameVerifier() throws Exception {
+        WSClient client = new WSClient("https://192.0.2.1/sdk", false);
+        HttpsURLConnection con = (HttpsURLConnection) new URL("https://192.0.2.1/sdk").openConnection();
+        HostnameVerifier original = con.getHostnameVerifier();
+
+        client.applyHttpsConfig(con);
+
+        // When ignoreCert=false we honor the JDK's default hostname verification;
+        // overriding here would silently weaken security for users who didn't ask for it.
+        assertSame("hostname verifier should be untouched when ignoreCert=false",
+            original, con.getHostnameVerifier());
     }
 }


### PR DESCRIPTION
## Summary

Connecting to vSphere by IP address with `ignoreCert=true` failed with:

```
javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException:
No subject alternative names matching IP address 127.0.0.1 found
```

vSphere certs don't carry the IP in their SAN, so the JDK's default hostname verifier rejects the connection. The previous fix relied on `HttpsURLConnection.setDefaultHostnameVerifier(...)` called inside `TrustAllSSL.getTrustContext()`, which is global, mutable, and timing-fragile — a connection that captured the JDK default before the override took effect ignored it and rejected the IP. Reproduced by users on vSphere 5.0, 6.0, and 6.5 over multiple years (alawrenc, vThinkBeyondVM, bbsantosh, aapfactory, carterg).

## Changes

- `TrustAllSSL.getTrustAllHostnameVerifier()` exposes a shared `HostnameVerifier` (singleton) so `WSClient` doesn't allocate per request.
- `WSClient` stores the verifier (non-null only when `ignoreCert=true`) and applies it on every `HttpsURLConnection` it opens via a new `applyHttpsConfig` helper. Same call also handles the `SSLSocketFactory`, keeping HTTPS connection setup in one place.
- When `ignoreCert=false` the verifier is left `null` and the JDK default hostname verification is preserved — **no silent security weakening** for users who didn't ask for it.

## Verification (TDD)

4 new tests, all verified red→green:

`WSClientTest`:
1. `applyHttpsConfig_ignoreCertTrue_setsTrustAllHostnameVerifierOnConnection` — opens a real (non-network) `HttpsURLConnection`, runs config, asserts the verifier accepts arbitrary hostnames AND IP literals.
2. `applyHttpsConfig_ignoreCertFalse_doesNotOverrideHostnameVerifier` — asserts default is preserved.

`TrustAllSSLTest`:
3. `getTrustAllHostnameVerifier_returnsVerifierThatAcceptsAnyHostname`
4. `getTrustAllHostnameVerifier_returnsSameInstanceAcrossCalls`

All compile-fail or assertion-fail against pre-fix code; pass after.

## Test plan

- [x] New tests fail against pre-fix code
- [x] New tests pass with fix
- [x] Full test suite passes

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)