### PR TITLE
fix: Guest*Manager vm=null NPE, SoapClient/VerUtil default encoding

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/GuestAuthManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestAuthManager.java
@@ -27,6 +27,9 @@ public class GuestAuthManager extends ManagedObject {
     public VirtualMachine getVM() {
     return vm;
 }
+    public void setVM(VirtualMachine vm) {
+    this.vm = vm;
+}
     public GuestAuthentication acquireCredentialsInGuest(GuestAuthentication requestedAuth, long sessionID) throws GuestOperationsFault, TaskInProgress, InvalidState, RuntimeFault, RemoteException {
     return getVimService().acquireCredentialsInGuest(this.getMOR(), vm.getMOR(), requestedAuth, sessionID);
 }

--- a/src/main/java/com/vmware/vim25/mo/GuestFileManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestFileManager.java
@@ -51,6 +51,9 @@ public class GuestFileManager extends ManagedObject {
     public VirtualMachine getVM() {
     return vm;
 }
+    public void setVM(VirtualMachine vm) {
+    this.vm = vm;
+}
     public String createTemporaryDirectoryInGuest(GuestAuthentication auth, String prefix, String suffix, String directoryPath) throws GuestOperationsFault, InvalidState, TaskInProgress, FileFault, RuntimeFault, RemoteException {
     return getVimService().createTemporaryDirectoryInGuest(getMOR(), vm.getMOR(), auth, prefix, suffix, directoryPath);
 }

--- a/src/main/java/com/vmware/vim25/mo/GuestOperationsManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestOperationsManager.java
@@ -30,15 +30,21 @@ public class GuestOperationsManager extends ManagedObject {
     /* ===== BEGIN custom (preserved by regenerator) ===== */
     public GuestAuthManager getAuthManager(VirtualMachine vm) {
     ManagedObjectReference mor = (ManagedObjectReference) getCurrentProperty("authManager");
-    return new GuestAuthManager(getServerConnection(), mor);
+    GuestAuthManager am = new GuestAuthManager(getServerConnection(), mor);
+    am.setVM(vm);
+    return am;
 }
     public GuestFileManager getFileManager(VirtualMachine vm) {
     ManagedObjectReference mor = (ManagedObjectReference) getCurrentProperty("fileManager");
-    return new GuestFileManager(getServerConnection(), mor);
+    GuestFileManager fm = new GuestFileManager(getServerConnection(), mor);
+    fm.setVM(vm);
+    return fm;
 }
     public GuestProcessManager getProcessManager(VirtualMachine vm) {
     ManagedObjectReference mor = (ManagedObjectReference) getCurrentProperty("processManager");
-    return new GuestProcessManager(getServerConnection(), mor);
+    GuestProcessManager pm = new GuestProcessManager(getServerConnection(), mor);
+    pm.setVM(vm);
+    return pm;
 }
     /**
  * A managed object that provides methods to support single sign-on in the guest operating system.

--- a/src/main/java/com/vmware/vim25/mo/GuestProcessManager.java
+++ b/src/main/java/com/vmware/vim25/mo/GuestProcessManager.java
@@ -35,6 +35,9 @@ public class GuestProcessManager extends ManagedObject {
     public VirtualMachine getVM() {
     return vm;
 }
+    public void setVM(VirtualMachine vm) {
+    this.vm = vm;
+}
     public GuestProcessInfo[] listProcessesInGuest(GuestAuthentication auth, long[] pids) throws GuestOperationsFault, InvalidState, TaskInProgress, RuntimeFault, RemoteException {
     return getVimService().listProcessesInGuest(getMOR(), vm.getMOR(), auth, pids);
 }

--- a/src/main/java/com/vmware/vim25/mo/util/VerUtil.java
+++ b/src/main/java/com/vmware/vim25/mo/util/VerUtil.java
@@ -33,6 +33,7 @@ import javax.net.ssl.*;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.security.KeyManagementException;
@@ -100,13 +101,14 @@ public class VerUtil {
         URL url = new URL(urlStr);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.connect();
-        BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
-
-        String xmlWSDL = "";
-        String line;
-        while ((line = in.readLine()) != null) {
-            xmlWSDL = xmlWSDL + line;
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = in.readLine()) != null) {
+                sb.append(line);
+            }
         }
+        String xmlWSDL = sb.toString();
 
         int start = xmlWSDL.indexOf("targetNamespace") + "targetNamespace".length();
         start = xmlWSDL.indexOf("\"", start);

--- a/src/main/java/com/vmware/vim25/ws/SoapClient.java
+++ b/src/main/java/com/vmware/vim25/ws/SoapClient.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -245,7 +246,7 @@ public abstract class SoapClient implements Client {
     public StringBuffer readStream(InputStream is) throws IOException {
         log.trace("Building StringBuffer from InputStream response.");
         StringBuffer sb = new StringBuffer();
-        BufferedReader in = new BufferedReader(new InputStreamReader(is));
+        BufferedReader in = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
         String lineStr;
         while ((lineStr = in.readLine()) != null) {
             sb.append(lineStr);

--- a/src/test/java/com/vmware/vim25/mo/GuestManagersTest.java
+++ b/src/test/java/com/vmware/vim25/mo/GuestManagersTest.java
@@ -1,0 +1,50 @@
+package com.vmware.vim25.mo;
+
+import com.vmware.vim25.ManagedObjectReference;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Verifies that Guest*Manager convenience overloads are reachable — i.e., that GuestOperationsManager
+ * injects the VirtualMachine reference into the returned managers (issue: vm field was always null).
+ */
+public class GuestManagersTest {
+
+    private static ManagedObjectReference mor(String type, String val) {
+        ManagedObjectReference m = new ManagedObjectReference();
+        m.setType(type);
+        m.setVal(val);
+        return m;
+    }
+
+    @Test
+    public void guestFileManager_setVM_storesVmForConvenienceOverloads() {
+        GuestFileManager fm = new GuestFileManager(null, mor("GuestFileManager", "fm-1"));
+        VirtualMachine vm = new VirtualMachine(null, mor("VirtualMachine", "vm-1"));
+
+        assertNull("vm should be null before setVM", fm.getVM());
+        fm.setVM(vm);
+        assertSame("getVM() must return the vm passed to setVM", vm, fm.getVM());
+    }
+
+    @Test
+    public void guestProcessManager_setVM_storesVmForConvenienceOverloads() {
+        GuestProcessManager pm = new GuestProcessManager(null, mor("GuestProcessManager", "pm-1"));
+        VirtualMachine vm = new VirtualMachine(null, mor("VirtualMachine", "vm-1"));
+
+        assertNull("vm should be null before setVM", pm.getVM());
+        pm.setVM(vm);
+        assertSame("getVM() must return the vm passed to setVM", vm, pm.getVM());
+    }
+
+    @Test
+    public void guestAuthManager_setVM_storesVmForConvenienceOverloads() {
+        GuestAuthManager am = new GuestAuthManager(null, mor("GuestAuthManager", "am-1"));
+        VirtualMachine vm = new VirtualMachine(null, mor("VirtualMachine", "vm-1"));
+
+        assertNull("vm should be null before setVM", am.getVM());
+        am.setVM(vm);
+        assertSame("getVM() must return the vm passed to setVM", vm, am.getVM());
+    }
+}

--- a/src/test/java/com/vmware/vim25/ws/SoapClientTest.java
+++ b/src/test/java/com/vmware/vim25/ws/SoapClientTest.java
@@ -114,6 +114,17 @@ public class SoapClientTest {
         assertEquals("line1line2line3", client.readStream(is).toString());
     }
 
+    @Test
+    public void readStream_utf8NonAsciiContent_preservesCharacters() throws Exception {
+        // SOAP responses from vSphere are UTF-8. VM names / descriptions can contain
+        // non-ASCII characters (e.g. German umlauts, accented chars). Without an explicit
+        // charset the JDK uses the platform default, which corrupts these characters on
+        // non-UTF-8 systems.
+        String input = "München-VM Résumé Ñoño";
+        InputStream is = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+        assertEquals(input, client.readStream(is).toString());
+    }
+
     // --- marshall ---
 
     @Test


### PR DESCRIPTION
## Summary

Three bugs found by SpotBugs static analysis during the 9.0 pre-release review:

- **Guest*Manager convenience overloads always NPE** — `GuestFileManager`, `GuestProcessManager`, and `GuestAuthManager` each have no-arg convenience overloads that rely on a private `vm` field. `GuestOperationsManager.get*Manager(VirtualMachine vm)` accepted the vm parameter but silently discarded it, leaving the field null. Every call to the shorter overloads (e.g., `pm.startProgramInGuest(auth, spec)`) threw NPE. Fixed by adding `setVM()` to each manager and calling it in `GuestOperationsManager` after construction.

- **SoapClient.readStream uses platform default charset** — SOAP responses are UTF-8; VM names and descriptions can contain non-ASCII (umlauts, accents, etc.). Without an explicit charset, responses are silently corrupted on Windows or any JVM whose default is not UTF-8. Fixed with `StandardCharsets.UTF_8`.

- **VerUtil.getTargetNameSpace stream not closed + same charset bug** — The `BufferedReader` was not wrapped in try-with-resources (SpotBugs OS), and used the same platform-default charset. Fixed both.

## Test plan
- [ ] `GuestManagersTest` — 3 new tests verify `setVM`/`getVM` round-trip on all three managers
- [ ] `SoapClientTest.readStream_utf8NonAsciiContent_preservesCharacters` — documents UTF-8 requirement
- [ ] Full suite passes (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)