### PR TITLE
fix: switch to Sonatype Central Portal API for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Publish
-        # Routes automatically: SNAPSHOT → central.sonatype.com/repository/maven-snapshots/
-        #                        release  → ossrh-staging-api.central.sonatype.com (signed)
+        # SNAPSHOT → publishAllPublicationsToCentralSnapshots (no signing required)
+        # release  → publishAllPublicationsToCentralPortal (signed, AUTOMATIC delivery)
         # Required secrets: MAVEN_CENTRAL_USERNAME, MAVEN_CENTRAL_PASSWORD
         # Release-only:     GPG_SIGNING_KEY (ASCII-armored), GPG_SIGNING_KEY_ID, GPG_SIGNING_PASSWORD
         env:
@@ -32,4 +32,10 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.GPG_SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-        run: ./gradlew publish
+        run: |
+          VERSION=$(grep '^version' build.gradle | sed "s/version = '//;s/'//")
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            ./gradlew publishAllPublicationsToCentralSnapshots
+          else
+            ./gradlew publishAllPublicationsToCentralPortal
+          fi

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'signing'
     id 'com.github.spotbugs' version '6.5.4'
     id 'org.owasp.dependencycheck' version '12.2.1'
+    id 'com.gradleup.nmcp' version '1.5.0'
 }
 
 group = "com.toastcoders"
@@ -128,7 +129,7 @@ dependencyCheck {
 }
 
 signing {
-    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+    required { isReleaseVersion }
     def signingKey = findProperty('signingKey')
     def signingKeyId = findProperty('signingKeyId')
     def signingPassword = findProperty('signingPassword')
@@ -137,9 +138,6 @@ signing {
     }
     sign publishing.publications
 }
-
-def mavenCentralUsername = findProperty('mavenCentralUsername') ?: ''
-def mavenCentralPassword = findProperty('mavenCentralPassword') ?: ''
 
 publishing {
     publications {
@@ -176,16 +174,12 @@ publishing {
             }
         }
     }
+}
 
-    repositories {
-        maven {
-            def releasesUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
-            def snapshotsUrl = "https://central.sonatype.com/repository/maven-snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsUrl : releasesUrl
-            credentials {
-                username = mavenCentralUsername
-                password = mavenCentralPassword
-            }
-        }
+nmcp {
+    publishAllPublications {
+        username = findProperty('mavenCentralUsername') ?: ''
+        password = findProperty('mavenCentralPassword') ?: ''
+        publishingType = "AUTOMATIC"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'com.github.spotbugs' version '6.5.4'
     id 'org.owasp.dependencycheck' version '12.2.1'
     id 'com.gradleup.nmcp' version '1.5.0'
+    id 'com.gradleup.nmcp.aggregation' version '1.5.0'
 }
 
 group = "com.toastcoders"
@@ -176,10 +177,14 @@ publishing {
     }
 }
 
-nmcp {
-    publishAllPublications {
+nmcpAggregation {
+    centralPortal {
         username = findProperty('mavenCentralUsername') ?: ''
         password = findProperty('mavenCentralPassword') ?: ''
         publishingType = "AUTOMATIC"
     }
+}
+
+dependencies {
+    nmcpAggregation project(':')
 }


### PR DESCRIPTION
## Problem

The previous `build.gradle` used the legacy OSSRH compatibility endpoint (`ossrh-staging-api.central.sonatype.com`), which requires credentials from a migrated oss.sonatype.org account. New Central Portal accounts use token-based auth that is incompatible with that endpoint — uploads appeared to succeed but nothing showed up in the portal.

## Fix

- Replace the legacy repository URL with [`com.gradleup.nmcp`](https://gradleup.com/nmcp/) 1.5.0, the community-standard Gradle plugin for the new Central Publisher Portal API
- `publishingType = "AUTOMATIC"` means releases go live without a manual portal promotion step
- Workflow now runs `publishAllPublicationsToCentralPortal` for releases and `publishAllPublicationsToCentralSnapshots` for SNAPSHOTs

## After merging

Delete the `v9.0.0` tag and re-push it to trigger a clean publish run:
```bash
git tag -d v9.0.0
git push origin :refs/tags/v9.0.0
git tag v9.0.0
git push origin v9.0.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)