### PR TITLE
fix: use correct aggregation task names in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           VERSION=$(grep '^version' build.gradle | sed "s/version = '//;s/'//")
           if [[ "$VERSION" == *-SNAPSHOT ]]; then
-            ./gradlew publishAllPublicationsToCentralSnapshots
+            ./gradlew publishAggregationToCentralSnapshots
           else
-            ./gradlew publishAllPublicationsToCentralPortal
+            ./gradlew publishAggregationToCentralPortal
           fi


### PR DESCRIPTION
## Problem

The workflow was calling `publishAllPublicationsToCentralPortal`, which is provided by the `com.gradleup.nmcp` plugin and reads credentials from an `nmcp {}` block. Credentials are configured in `nmcpAggregation { centralPortal {} }`, which feeds the `publishAggregationToCentralPortal` task from the `com.gradleup.nmcp.aggregation` plugin. Mismatch caused "username is missing" even though secrets were set.

## Fix

Switch workflow task names:
- `publishAllPublicationsToCentralPortal` → `publishAggregationToCentralPortal`
- `publishAllPublicationsToCentralSnapshots` → `publishAggregationToCentralSnapshots`

🤖 Generated with [Claude Code](https://claude.com/claude-code)