### PR TITLE
chore: upgrade Gradle wrapper to 9.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,9 @@ plugins {
 }
 
 group = "com.toastcoders"
-archivesBaseName = "yavijava"
+base.archivesName = "yavijava"
 version = '9.0'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-targetCompatibility = JavaVersion.VERSION_21
-sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Fri Feb 20 21:59:32 CST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip


### PR DESCRIPTION
## Summary

- Bumps Gradle wrapper from 8.13 → 9.5.0
- Fixes two Gradle 9 removals that were hard errors under 9.x:
  - `archivesBaseName` → `base.archivesName` (BasePluginConvention removed)
  - Removed top-level `sourceCompatibility`/`targetCompatibility` (JavaPluginConvention removed; toolchain block already sets Java 21)

## What's left (step 2)

One Gradle 10 deprecation remains — Groovy space-call syntax in `testLogging { events ... }`. Not a Gradle 9 issue; tracked for a follow-up PR.

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)