### PR TITLE
chore: fix Gradle 10 deprecation in signing block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ dependencyCheck {
 }
 
 signing {
-    required { isReleaseVersion }
+    required = isReleaseVersion
     def signingKey = findProperty('signingKey')
     def signingKeyId = findProperty('signingKeyId')
     def signingPassword = findProperty('signingPassword')


### PR DESCRIPTION
## Summary

- Fixes the last remaining deprecation warning introduced by the Gradle 9.5 upgrade
- `required { isReleaseVersion }` → `required = isReleaseVersion` in the signing block
- The Groovy space-call/method syntax for property setters is removed in Gradle 10; direct assignment is the correct form

Build now runs fully clean with zero deprecation warnings under Gradle 9.5.0.

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)