### PR TITLE
fix(security): upgrade log4j to 2.25.4 and suppress false positives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,15 @@ spotbugsMain {
 spotbugsTest.enabled = false
 spotbugsIntTest.enabled = false
 
+// Force log4j to a version that fixes CVE-2026-34478, CVE-2026-34480, CVE-2026-34481,
+// and CVE-2025-68161. SpotBugs pulls in 2.25.2; 2.25.4 is within its [2.17.1,3) range.
+configurations.all {
+    resolutionStrategy {
+        force 'org.apache.logging.log4j:log4j-core:2.25.4'
+        force 'org.apache.logging.log4j:log4j-api:2.25.4'
+    }
+}
+
 // --- OWASP Dependency-Check (run explicitly: ./gradlew dependencyCheckAnalyze) ---
 // Not wired into `check` because it requires downloading the NVD database (~200 MB).
 // Run periodically in CI as a separate job.

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,12 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <!--
-    Add suppression entries here for known false positives.
-    Format:
-      <suppress>
-        <notes>Why this is suppressed</notes>
-        <gav regex="true">^group:artifact:.*$</gav>
-        <cve>CVE-YYYY-NNNNN</cve>
-      </suppress>
-  -->
+
+  <!-- FALSE POSITIVES: gratatouille-tasks-runtime and nmcp-tasks -->
+  <!-- CVE-2020-22475 and CVE-2022-39349 are for the "Tasks" Android/mobile app
+       (insecure permissions / XSS). The CPE matcher is keying on the word "tasks"
+       in the JAR name, but these are Gradle build-time plugin JARs with no
+       relationship to that product. -->
+  <suppress>
+    <notes>False positive: CVE-2020-22475 is for a "Tasks" Android app, not the gratatouille Gradle plugin runtime.</notes>
+    <packageUrl regex="true">^pkg:maven/com\.gradleup\.gratatouille/gratatouille-tasks-runtime@.*$</packageUrl>
+    <cve>CVE-2020-22475</cve>
+  </suppress>
+  <suppress>
+    <notes>False positive: CVE-2022-39349 is for the Tasks Android app, not the gratatouille Gradle plugin runtime.</notes>
+    <packageUrl regex="true">^pkg:maven/com\.gradleup\.gratatouille/gratatouille-tasks-runtime@.*$</packageUrl>
+    <cve>CVE-2022-39349</cve>
+  </suppress>
+  <suppress>
+    <notes>False positive: CVE-2020-22475 is for a "Tasks" Android app, not the nmcp Gradle plugin.</notes>
+    <packageUrl regex="true">^pkg:maven/com\.gradleup\.nmcp/nmcp-tasks@.*$</packageUrl>
+    <cve>CVE-2020-22475</cve>
+  </suppress>
+  <suppress>
+    <notes>False positive: CVE-2022-39349 is for the Tasks Android app, not the nmcp Gradle plugin.</notes>
+    <packageUrl regex="true">^pkg:maven/com\.gradleup\.nmcp/nmcp-tasks@.*$</packageUrl>
+    <cve>CVE-2022-39349</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
## Summary

- Forces `log4j-core` and `log4j-api` to 2.25.4 via `resolutionStrategy`, resolving four CVEs introduced transitively by SpotBugs 4.9.8
- Suppresses four false-positive findings on `gratatouille-tasks-runtime` and `nmcp-tasks` (CPE mismatch with an unrelated Android "Tasks" app)

## CVEs resolved

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-34481 | Critical (>7.0) | Log4j Rfc5424Layout CRLF injection via renamed config attribute |
| CVE-2026-34480 | Critical (>7.0) | Log4j XmlLayout silent data loss / malformed XML on forbidden chars |
| CVE-2026-34478 | Critical (>7.0) | Log4j Core log injection vulnerability |
| CVE-2025-68161 | Medium | Log4j Socket Appender skips TLS hostname verification |

## False positives suppressed

| JAR | CVEs | Reason |
|-----|------|--------|
| `gratatouille-tasks-runtime` | CVE-2020-22475, CVE-2022-39349 | OWASP CPE matcher keys on "tasks" in JAR name; CVEs are for an Android "Tasks" app |
| `nmcp-tasks` | CVE-2020-22475, CVE-2022-39349 | Same CPE mismatch |

## Test plan

- [ ] Run `./gradlew dependencyCheckAnalyze -PnvdApiKey="<key>"` and confirm zero findings above CVSS 7.0
- [ ] Run `./gradlew check` to confirm SpotBugs and tests still pass with the forced log4j version

🤖 Generated with [Claude Code](https://claude.com/claude-code)