### PR TITLE
fix(ws): handle byte[][] fields in XmlGenDom deserializer

### DIFF
--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -319,7 +319,18 @@ class XmlGenDom extends XmlGen {
                 }
             }
 
-            if (fRealType == ManagedObjectReference.class) { // MOR
+            // byte[][] would otherwise be misread as a single byte[] via base64Binary after getComponentType()
+            if (field.getType() == byte[][].class) {
+                int count = getNumberOfSameTags(subNodes, sizeOfSubNodes, i, tagName);
+                byte[][] result = new byte[count][];
+                for (int j = 0; j < count; j++) {
+                    String text = ((Element) subNodes.get(j + i)).getText().trim();
+                    result[j] = java.util.Base64.getDecoder().decode(text);
+                }
+                field.set(obj, result);
+                i = i + count - 1;
+            }
+            else if (fRealType == ManagedObjectReference.class) { // MOR
                 if (isFieldArray) {
                     int sizeOfFieldArray = getNumberOfSameTags(subNodes, sizeOfSubNodes, i, tagName);
                     ManagedObjectReference[] mos = new ManagedObjectReference[sizeOfFieldArray];

--- a/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGenDom.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.List;
 
@@ -325,10 +326,11 @@ class XmlGenDom extends XmlGen {
                 byte[][] result = new byte[count][];
                 for (int j = 0; j < count; j++) {
                     String text = ((Element) subNodes.get(j + i)).getText().trim();
-                    result[j] = java.util.Base64.getDecoder().decode(text);
+                    result[j] = Base64.getDecoder().decode(text);
                 }
                 field.set(obj, result);
                 i = i + count - 1;
+                continue;
             }
             else if (fRealType == ManagedObjectReference.class) { // MOR
                 if (isFieldArray) {

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -244,7 +244,7 @@ public class XmlGenDomTest {
     }
 
     @Test
-    public void testFromXML_VirtualTPM_with_byteArrayArray_field_deserializes_correctly() throws Exception {
+    public void testFromXML_VirtualTPM_with_byteArrayArray_fields_deserialize_correctly() throws Exception {
         InputStream inputStream = new FileInputStream(new File("src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml"));
         XmlGenDom xmlGenDom = new XmlGenDom();
         VirtualTPM vtpm = (VirtualTPM) xmlGenDom.fromXML("VirtualTPM", inputStream);
@@ -257,6 +257,14 @@ public class XmlGenDomTest {
             new byte[]{0x01, 0x02, 0x03}, vtpm.endorsementKeyCertificateSigningRequest[0]);
         Assert.assertArrayEquals("second CSR entry should decode to 0x04 0x05 0x06",
             new byte[]{0x04, 0x05, 0x06}, vtpm.endorsementKeyCertificateSigningRequest[1]);
+        Assert.assertNotNull("endorsementKeyCertificate should not be null",
+            vtpm.endorsementKeyCertificate);
+        Assert.assertEquals("should have 2 certificate entries", 2,
+            vtpm.endorsementKeyCertificate.length);
+        Assert.assertArrayEquals("first certificate entry should decode to 0x07 0x08 0x09",
+            new byte[]{0x07, 0x08, 0x09}, vtpm.endorsementKeyCertificate[0]);
+        Assert.assertArrayEquals("second certificate entry should decode to 0x0A 0x0B 0x0C",
+            new byte[]{0x0A, 0x0B, 0x0C}, vtpm.endorsementKeyCertificate[1]);
     }
 
     @Test

--- a/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java
@@ -244,6 +244,22 @@ public class XmlGenDomTest {
     }
 
     @Test
+    public void testFromXML_VirtualTPM_with_byteArrayArray_field_deserializes_correctly() throws Exception {
+        InputStream inputStream = new FileInputStream(new File("src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml"));
+        XmlGenDom xmlGenDom = new XmlGenDom();
+        VirtualTPM vtpm = (VirtualTPM) xmlGenDom.fromXML("VirtualTPM", inputStream);
+        Assert.assertNotNull("VirtualTPM should not be null", vtpm);
+        Assert.assertNotNull("endorsementKeyCertificateSigningRequest should not be null",
+            vtpm.endorsementKeyCertificateSigningRequest);
+        Assert.assertEquals("should have 2 CSR entries", 2,
+            vtpm.endorsementKeyCertificateSigningRequest.length);
+        Assert.assertArrayEquals("first CSR entry should decode to 0x01 0x02 0x03",
+            new byte[]{0x01, 0x02, 0x03}, vtpm.endorsementKeyCertificateSigningRequest[0]);
+        Assert.assertArrayEquals("second CSR entry should decode to 0x04 0x05 0x06",
+            new byte[]{0x04, 0x05, 0x06}, vtpm.endorsementKeyCertificateSigningRequest[1]);
+    }
+
+    @Test
     public void testFromXML_PerfCounterInfoWithUnknownSubtype_ParsesGracefully() throws Exception {
         InputStream inputStream = new FileInputStream(
             new File("src/test/java/com/vmware/vim25/ws/xml/PerfCounterInfoWithUnknownSubtype.xml"));

--- a/src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml
+++ b/src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml
@@ -8,6 +8,8 @@
             <returnval>
                 <endorsementKeyCertificateSigningRequest>AQID</endorsementKeyCertificateSigningRequest>
                 <endorsementKeyCertificateSigningRequest>BAUG</endorsementKeyCertificateSigningRequest>
+                <endorsementKeyCertificate>BwgJ</endorsementKeyCertificate>
+                <endorsementKeyCertificate>CgsM</endorsementKeyCertificate>
             </returnval>
         </RetrievePropertiesResponse>
     </soapenv:Body>

--- a/src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml
+++ b/src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <RetrievePropertiesResponse xmlns="urn:vim25">
+            <returnval>
+                <endorsementKeyCertificateSigningRequest>AQID</endorsementKeyCertificateSigningRequest>
+                <endorsementKeyCertificateSigningRequest>BAUG</endorsementKeyCertificateSigningRequest>
+            </returnval>
+        </RetrievePropertiesResponse>
+    </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Fixes #352.

## Summary

`VirtualMachine.getConfig()` threw `IllegalArgumentException: Can not set [[B field ... to [B` on any VM with a vTPM device (Windows 11 mandates vTPM). Root cause: in `XmlGenDom.fromXml()`, the array branch calls `getComponentType()` once, collapsing `byte[][]` to `byte[]`. `TypeUtil.isBasicType(byte[])` then returns true (treated as base64Binary), so the deserializer built a single `byte[]` and tried to assign it to a `byte[][]` field.

Fix: special-case `field.getType() == byte[][].class` before the basic-array branch — count consecutive same-name sibling tags, decode each as base64, build a `byte[][]`, and advance the loop index.

## Changes

- `src/main/java/com/vmware/vim25/ws/XmlGenDom.java` — new `byte[][]` branch (places it before the basic-array branch, with explicit `continue` matching peer arms).
- `src/test/java/com/vmware/vim25/ws/XmlGenDomTest.java` — `testFromXML_VirtualTPM_with_byteArrayArray_fields_deserialize_correctly` covers both `byte[][]` fields on `VirtualTPM`.
- `src/test/resources/xml/VirtualTPMWithEndorsementKeyCSR.xml` — minimal `<VirtualTPM>` fixture: two `endorsementKeyCertificateSigningRequest` entries followed by two `endorsementKeyCertificate` entries (grouped layout matches the WSDL `<sequence>` ordering).

## Test plan

- [x] `./gradlew test --tests "com.vmware.vim25.ws.XmlGenDomTest.testFromXML_VirtualTPM_with_byteArrayArray_fields_deserialize_correctly"` — passes; before the fix it failed with the issue's exact `IllegalArgumentException`.
- [x] `./gradlew check` — full unit test + SpotBugs suite green; existing single-dim `byte[]` tests (`testFromXML_vmxConfigChecksum_with_Base64_value_parses_correctly_to_byteArray`, `testFromXML_payload_with_normal_byte_array_parses_into_byte_array`) unchanged.

## Notes

- The test asserts decoded bytes (`assertArrayEquals`) for each cell of both `byte[][]` fields, not just lengths, so a shape-swap bug would be caught.
- Reviewed the WSDL: `VirtualTPM`'s `<sequence>` mandates all CSR elements before all cert elements, so any conforming vSphere response will be grouped — the fixture matches production shape.
- No generated-file edits. Only hand-written `ws/XmlGenDom.java` was modified on the prod side.