### PR TITLE
fix(ws): skip static fields in XmlGen.toXML to silence serialVersionUID log spam

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     implementation 'org.dom4j:dom4j:2.1.4'
     implementation 'org.slf4j:slf4j-api:2.0.17'
-    testRuntimeOnly 'ch.qos.logback:logback-classic:1.5.32'
+    testImplementation 'ch.qos.logback:logback-classic:1.5.32'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.5.2'
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/src/main/java/com/vmware/vim25/ws/XmlGen.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGen.java
@@ -184,6 +184,7 @@ public abstract class XmlGen {
                         value = f.get(obj);
                     }
                     catch (IllegalAccessException iae) {
+                        // Defensive: static fields are skipped by the guard above; this remains for any other access failure.
                         log.error("IllegalAccessException caught.", iae);
                     }
                 }

--- a/src/main/java/com/vmware/vim25/ws/XmlGen.java
+++ b/src/main/java/com/vmware/vim25/ws/XmlGen.java
@@ -178,7 +178,8 @@ public abstract class XmlGen {
                 String fName = f.getName();
 
                 Object value = null;
-                if (!Modifier.isTransient(f.getModifiers())) {
+                // Skip static fields (e.g. serialVersionUID): Field.get on a private static throws IllegalAccessException
+                if (!Modifier.isTransient(f.getModifiers()) && !Modifier.isStatic(f.getModifiers())) {
                     try {
                         value = f.get(obj);
                     }

--- a/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
@@ -1,8 +1,15 @@
 package com.vmware.vim25.ws;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.vmware.vim25.ArrayOfHostRdmaDevice;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
 import java.util.Calendar;
+import java.util.List;
 import java.util.TimeZone;
 
 import static org.junit.Assert.*;
@@ -34,5 +41,49 @@ public class XmlGenTest {
 
         // The serialized value must contain the date — format varies by impl but year/month/day must be present
         assertTrue("XML should contain the date 2015-06-19", xml.contains("2015-06-19"));
+    }
+
+    @Test
+    public void toXML_serializingArrayOfWithSerialVersionUID_doesNotLogIllegalAccess() {
+        // Attach a ListAppender to the XmlGen logger to capture log events during serialization.
+        Logger xmlGenLogger = (Logger) LoggerFactory.getLogger("com.vmware.vim25.ws.XmlGen");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        xmlGenLogger.addAppender(appender);
+        try {
+            ArrayOfHostRdmaDevice payload = new ArrayOfHostRdmaDevice();
+            Argument[] args = new Argument[]{new Argument("devices", "ArrayOfHostRdmaDevice", payload)};
+            XmlGen.toXML("testMethod", args, " xmlns=\"urn:vim25\"");
+
+            List<ILoggingEvent> events = appender.list;
+            for (ILoggingEvent event : events) {
+                if (event.getLevel() == Level.ERROR) {
+                    Throwable t = event.getThrowableProxy() != null
+                            ? (event.getThrowableProxy() instanceof ch.qos.logback.classic.spi.ThrowableProxy
+                                ? ((ch.qos.logback.classic.spi.ThrowableProxy) event.getThrowableProxy()).getThrowable()
+                                : null)
+                            : null;
+                    boolean mentionsIllegalAccess = event.getFormattedMessage().contains("IllegalAccessException")
+                            || (t instanceof IllegalAccessException);
+                    assertFalse(
+                            "XmlGen must not log ERROR for IllegalAccessException on serialVersionUID, but got: "
+                                    + event.getFormattedMessage(),
+                            mentionsIllegalAccess);
+                }
+            }
+        } finally {
+            xmlGenLogger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @Test
+    public void toXML_serializedXml_doesNotContainStaticSerialVersionUID() {
+        ArrayOfHostRdmaDevice payload = new ArrayOfHostRdmaDevice();
+        Argument[] args = new Argument[]{new Argument("devices", "ArrayOfHostRdmaDevice", payload)};
+        String xml = XmlGen.toXML("testMethod", args, " xmlns=\"urn:vim25\"");
+
+        assertFalse("Serialized XML must not contain serialVersionUID — static fields must be skipped",
+                xml.contains("serialVersionUID"));
     }
 }

--- a/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
+++ b/src/test/java/com/vmware/vim25/ws/XmlGenTest.java
@@ -58,13 +58,10 @@ public class XmlGenTest {
             List<ILoggingEvent> events = appender.list;
             for (ILoggingEvent event : events) {
                 if (event.getLevel() == Level.ERROR) {
-                    Throwable t = event.getThrowableProxy() != null
-                            ? (event.getThrowableProxy() instanceof ch.qos.logback.classic.spi.ThrowableProxy
-                                ? ((ch.qos.logback.classic.spi.ThrowableProxy) event.getThrowableProxy()).getThrowable()
-                                : null)
-                            : null;
-                    boolean mentionsIllegalAccess = event.getFormattedMessage().contains("IllegalAccessException")
-                            || (t instanceof IllegalAccessException);
+                    boolean mentionsIllegalAccess =
+                        event.getFormattedMessage().contains("IllegalAccessException")
+                            || (event.getThrowableProxy() != null
+                                && event.getThrowableProxy().getClassName().equals(IllegalAccessException.class.getName()));
                     assertFalse(
                             "XmlGen must not log ERROR for IllegalAccessException on serialVersionUID, but got: "
                                     + event.getFormattedMessage(),
@@ -77,6 +74,8 @@ public class XmlGenTest {
         }
     }
 
+    // Regression guard: if a future refactor starts iterating static fields for serialization,
+    // this catches it. Does NOT detect the original log-spam bug — see the sibling symptom test.
     @Test
     public void toXML_serializedXml_doesNotContainStaticSerialVersionUID() {
         ArrayOfHostRdmaDevice payload = new ArrayOfHostRdmaDevice();


### PR DESCRIPTION
Fixes #353.

## Summary

Every VIM API call that serialized a request payload emitted an ERROR-level `IllegalAccessException` for each `Serializable` `ArrayOf*` class — the `private static final long serialVersionUID` slipped past the existing `transient`-only guard in `XmlGen.toXML()` and `Field.get()` threw on the private static field. The XML on the wire was correct (the catch-and-skip path produced `value == null`), but logs were polluted on every serialization.

Fix: tighten the field-iteration guard in `XmlGen.java` to skip static fields alongside transient ones:

```java
if (!Modifier.isTransient(f.getModifiers()) && !Modifier.isStatic(f.getModifiers())) {
    value = f.get(obj);
    ...
}
```

## Changes

- `src/main/java/com/vmware/vim25/ws/XmlGen.java` — adds `!Modifier.isStatic(...)` to the guard. A one-line defensive-keep comment now annotates the `catch (IllegalAccessException)` block to prevent future readers from removing it as dead code.
- `src/test/java/com/vmware/vim25/ws/XmlGenTest.java` — two new tests:
  - **Symptom test:** attaches a Logback `ListAppender` to the `com.vmware.vim25.ws.XmlGen` logger, serializes a payload containing `ArrayOfHostRdmaDevice` (which has `serialVersionUID` and implements `Serializable`), and asserts no ERROR event mentions `IllegalAccessException`. This test was RED pre-fix and is GREEN post-fix.
  - **Filter-logic test:** asserts the produced XML never contains `serialVersionUID`. This was already GREEN pre-fix (the bug logs but doesn't write); it serves as a forward-looking regression guard. A comment above the method documents this so git-history readers aren't confused.
- `build.gradle` — promotes `logback-classic` from `testRuntimeOnly` to `testImplementation` so the symptom test can import Logback types (`Logger`, `ListAppender`, `ILoggingEvent`, `IThrowableProxy`) at compile time. Production classpath unaffected.

## Test plan

- [x] `./gradlew test --tests "com.vmware.vim25.ws.XmlGenTest.toXML_serializingArrayOfWithSerialVersionUID_doesNotLogIllegalAccess"` — passes; pre-fix it failed by capturing `ERROR com.vmware.vim25.ws.XmlGen -- IllegalAccessException caught.` with `java.lang.IllegalAccessException` as the throwable.
- [x] `./gradlew test --tests "com.vmware.vim25.ws.XmlGenTest.toXML_serializedXml_doesNotContainStaticSerialVersionUID"` — passes.
- [x] `./gradlew check` — full unit-test + SpotBugs gate green.

## Notes

- `ReflectUtil.getAllFields()` returns all declared fields including static ones; filtering is the caller's responsibility. Only `XmlGen` calls it in production code, so this is the single site of the bug.
- The symptom test detection uses public Logback API (`IThrowableProxy.getClassName()`) plus formatted-message matching — no internal/implementation types.
- The ListAppender is detached in a `finally` block so it cannot leak between tests.