### PR TITLE
chore: cut 9.0.1 patch release

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -4,6 +4,15 @@ This document covers breaking changes and things to verify before upgrading your
 
 ---
 
+## 9.0.1 — Bug Fixes
+
+No breaking changes from 9.0. Bug fixes only:
+
+- **`VirtualMachine.getConfig()` `IllegalArgumentException` for VMs with vTPM (#352).** `XmlGenDom.fromXml()` collapsed `byte[][]` fields (`VirtualTPM.endorsementKeyCertificateSigningRequest`, `VirtualTPM.endorsementKeyCertificate`) to `byte[]` via a single `getComponentType()` call, then tried to assign the resulting `byte[]` to the `byte[][]` field. Any VM with a virtual TPM device — Windows 11 mandates one by default — threw on `getConfig()`. The deserializer now special-cases `byte[][]` fields and base64-decodes each element into the outer array.
+- **`ERROR` log spam from `serialVersionUID` on every serialization (#353).** `XmlGen.toXML()` iterated all declared fields and filtered only `transient`, so the `private static final long serialVersionUID` on every `Serializable` `ArrayOf*` class hit `Field.get()` and triggered an `IllegalAccessException` that was caught and logged at `ERROR`. Wire output was correct, but the noise was per-call. The field-iteration guard now also skips `static` fields.
+
+---
+
 ## Breaking Changes
 
 ### `com.vmware.vim.rest` Package Removed

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 group = "com.toastcoders"
 base.archivesName = "yavijava"
-version = '9.0'
+version = '9.0.1'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {

--- a/rel-note.txt
+++ b/rel-note.txt
@@ -1,3 +1,8 @@
+What is new in Version 9.0.1?
+Bug fixes:
+- VirtualMachine.getConfig() IllegalArgumentException on VMs with vTPM (byte[][] deserialization, #352)
+- XmlGen.toXML() ERROR log spam from serialVersionUID on Serializable ArrayOf* classes (#353)
+
 What is new in Version 9.0?
 vSphere 9.0 WSDL support (new managed objects, updated stubs)
 Apache HttpClient 4 → 5 migration (httpclient5:5.5.2)

--- a/src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java
+++ b/src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java
@@ -85,4 +85,30 @@ public class ReleaseNotesTest {
         assertTrue("Expected CacheInstance.awaitReady in UPDATES.md",
             updates().contains("awaitReady"));
     }
+
+    // --- 9.0.1 patch release ---
+
+    @Test
+    public void updatesDoc_documents901Section() throws IOException {
+        assertTrue("Expected 9.0.1 section heading in UPDATES.md",
+            updates().contains("9.0.1"));
+    }
+
+    @Test
+    public void updatesDoc_documentsVtpmByteArrayFix() throws IOException {
+        assertTrue("Expected VirtualTPM byte[][] fix entry in UPDATES.md",
+            updates().contains("VirtualTPM"));
+    }
+
+    @Test
+    public void updatesDoc_documentsSerialVersionUidLogSpamFix() throws IOException {
+        assertTrue("Expected serialVersionUID log spam fix entry in UPDATES.md",
+            updates().contains("serialVersionUID"));
+    }
+
+    @Test
+    public void relNote_hasVersion901Entry() throws IOException {
+        assertTrue("Expected 9.0.1 entry in rel-note.txt",
+            relNote().contains("9.0.1"));
+    }
 }


### PR DESCRIPTION
## Summary

Cuts a 9.0.1 patch release containing two bug fixes that have already merged to `gradle`:

- **#352** — `VirtualMachine.getConfig()` `IllegalArgumentException` on VMs with vTPM (`byte[][]` deserialization in `XmlGenDom`).
- **#353** — `ERROR` log spam from `serialVersionUID` on `Serializable` `ArrayOf*` classes (`XmlGen.toXML()` static-field guard).

No breaking changes from 9.0.

## Changes

- `build.gradle` — `version = '9.0'` → `version = '9.0.1'`. The `publish.yml` workflow keys off this string when a `v*` tag is pushed: SNAPSHOT → snapshots, otherwise sign + Central Portal staging.
- `rel-note.txt` — new `What is new in Version 9.0.1?` section prepended above the existing 9.0 entry.
- `UPDATES.md` — new `## 9.0.1 — Bug Fixes` section between the intro and the existing `## Breaking Changes` heading. The top-level `# Upgrade Notes — 9.0` title is preserved (9.0 breaking changes still apply to 9.0.1 upgraders).
- `src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java` — four new assertions gating the documented items: `9.0.1` section in UPDATES.md, `VirtualTPM` entry, `serialVersionUID` entry, and `9.0.1` in `rel-note.txt`. Existing `9.0` assertions are unchanged and still pass.

## Test plan

- [x] `./gradlew check` — full unit-test + SpotBugs gate green, including the four new `ReleaseNotesTest` assertions.

## How the release fires

After this PR merges to `gradle`, tag and push to trigger `publish.yml`:

```bash
git checkout gradle && git pull
git tag -a v9.0.1 -m "Release 9.0.1"
git push origin v9.0.1
```

The workflow signs with `GPG_SIGNING_KEY` and runs `publishAggregationToCentralPortal` (AUTOMATIC delivery). Tagging is left to the maintainer — this PR only stages the bump and notes.