### PR TITLE
chore(ci): bump Node 20 actions and auto-create GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,29 +11,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build and check
         run: ./gradlew check
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-results
           path: build/reports/tests/test/
 
       - name: Upload SpotBugs report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: spotbugs-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,20 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Publish
         # SNAPSHOT → publishAllPublicationsToCentralSnapshots (no signing required)
@@ -39,3 +41,24 @@ jobs:
           else
             ./gradlew publishAggregationToCentralPortal
           fi
+
+      - name: Create GitHub Release
+        # Skipped for SNAPSHOT builds and when a release already exists for this tag
+        # (e.g. maintainer created one manually). --generate-notes diffs against the
+        # previous tag; the maintainer can edit the body afterward.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep '^version' build.gradle | sed "s/version = '//;s/'//")
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "SNAPSHOT version, skipping GitHub Release"
+            exit 0
+          fi
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, skipping"
+            exit 0
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: OWASP Dependency-Check
         # NVD_API_KEY secret: add in repo Settings → Secrets for higher NVD rate limits.
@@ -28,7 +28,7 @@ jobs:
         run: ./gradlew dependencyCheckAnalyze -PnvdApiKey="${{ secrets.NVD_API_KEY }}"
 
       - name: Upload dependency-check report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: dependency-check-report


### PR DESCRIPTION
## Summary

Two unrelated-but-cheap CI cleanups bundled together:

1. **Bump deprecated Node.js 20 actions** across all three workflows. GitHub is removing Node 20 from runners on 2026-09-16 and the v9.0.1 publish run already surfaced the deprecation warning.
2. **Auto-create GitHub Releases** from successful Maven publishes, so future tags don't require manually clicking through the Releases UI (the v9.0.1 tag published to Maven Central but had no Release wrapper until it was created by hand).

## Changes

### Action bumps (ci.yml, publish.yml, security.yml)

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `gradle/actions/setup-gradle` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |

Each at their current latest major. The v5/v6/v7 lines all run on Node.js 24.

### `publish.yml` Release automation

- Adds `permissions: contents: write` to the `publish` job so the default `GITHUB_TOKEN` can create Releases.
- New `Create GitHub Release` step runs after the Maven publish. It:
  - No-ops on SNAPSHOT versions (read from `build.gradle`, same logic as the Publish step).
  - No-ops if a Release for the tag already exists (so manually-created Releases aren't overwritten).
  - Otherwise calls `gh release create <tag> --title <tag> --generate-notes --verify-tag`. `--generate-notes` diffs against the previous tag; you can edit the body afterward.

## Test plan

- [x] No source-code changes; `./gradlew check` is unaffected and not re-run locally.
- CI run on this PR will exercise the bumped `actions/checkout@v6`, `actions/setup-java@v5`, `gradle/actions/setup-gradle@v6`, and `actions/upload-artifact@v7` in `ci.yml`.
- The new `publish.yml` Release step is gated on a `v*` tag push — it won't fire on this PR. First real exercise will be the next release tag (`v9.0.2` or `v9.1.0`).

## Notes

- The Release-create step uses GitHub's own `gh` CLI (preinstalled on `ubuntu-latest` runners) — no third-party action dependency.
- `--verify-tag` requires the tag to exist before the Release is created, which is naturally satisfied since the workflow is triggered by the tag push.