### PR TITLE
docs: add governance docs and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,90 @@
+name: Bug report
+description: Something is broken or behaves incorrectly.
+title: "<short description of the problem>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much as you can — version info and a reproduction are what move a report from "we'll get to it" to "we can fix this."
+
+        If you suspect a security vulnerability, **do not** open this form — see [SECURITY.md](https://github.com/yavijava/yavijava/blob/gradle/SECURITY.md) for the private disclosure process.
+
+  - type: input
+    id: yavijava-version
+    attributes:
+      label: yavijava version
+      description: The version on your classpath (e.g. `9.0.1`). Check `build.gradle`, `pom.xml`, or the JAR.
+      placeholder: "9.0.1"
+    validations:
+      required: true
+
+  - type: input
+    id: vsphere-version
+    attributes:
+      label: vSphere / vCenter version
+      description: The version of vSphere or vCenter you were talking to when the problem occurred.
+      placeholder: "8.0 U2 / 9.0 / vcsim"
+    validations:
+      required: true
+
+  - type: input
+    id: jdk-version
+    attributes:
+      label: JDK version
+      description: Output of `java -version`.
+      placeholder: "OpenJDK 21.0.4"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: What did you do? Minimal code or shell commands are ideal.
+      placeholder: |
+        1. ServiceInstance si = new ServiceInstance(...)
+        2. VirtualMachine vm = (VirtualMachine) new InventoryNavigator(...).searchManagedEntity(...);
+        3. vm.getConfig();
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the exact exception, error message, or log line if you have one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stack trace
+      description: Paste the full stack trace if relevant. Wrap in triple-backticks for readability.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: suspected-cause
+    attributes:
+      label: Suspected cause or proposed fix
+      description: Optional. If you've already dug into the code, share what you found — it's often the fastest path to a merge.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/yavijava/yavijava/blob/gradle/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/yavijava/yavijava/discussions
+    about: Ask a usage question, share a pattern, or start an open-ended discussion. Please search existing discussions first.
+  - name: Security vulnerability
+    url: https://github.com/yavijava/yavijava/blob/gradle/SECURITY.md
+    about: Do NOT open a public issue. See SECURITY.md for the private disclosure process.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a new API surface, helper, or capability.
+title: "<short description of the feature>"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests are welcome but lower-priority than bug reports. The more clearly you can describe the *problem* the feature solves, the easier it is to evaluate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do? What's painful or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed feature
+      description: A sketch of the API or behavior you have in mind. Method signatures, class names, or sample usage are all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Why can the existing API not solve this?
+      description: Have you tried `mo/`, `mox/`, or a direct `VimStub` call? What's missing or awkward?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/yavijava/yavijava/blob/gradle/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,37 @@
+name: Question
+description: You have a usage question. (Prefer Discussions.)
+title: "<your question in one line>"
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most usage questions are a better fit for [GitHub Discussions](https://github.com/yavijava/yavijava/discussions) — they're searchable, others can answer, and they don't crowd the issue tracker.
+
+        Open an issue here only if:
+        - The behavior you're seeing might actually be a bug (in which case, use the **Bug report** template).
+        - The question is short and you've already searched Discussions and the README.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to do, and what's blocking you?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you've tried
+      description: Code snippets, API calls, or docs you've already looked at.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/yavijava/yavijava/blob/gradle/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/regression.yml
+++ b/.github/ISSUE_TEMPLATE/regression.yml
@@ -1,0 +1,63 @@
+name: Regression
+description: Something that used to work in a previous yavijava version now fails.
+title: "<short description of the regression>"
+labels: ["bug", "regression"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template if the same code worked on an earlier yavijava version and stopped working on a newer one. If you're not sure whether it ever worked, use the **Bug report** template instead.
+
+  - type: input
+    id: last-good-version
+    attributes:
+      label: Last yavijava version where it worked
+    validations:
+      required: true
+
+  - type: input
+    id: first-bad-version
+    attributes:
+      label: First yavijava version where it broke
+    validations:
+      required: true
+
+  - type: input
+    id: vsphere-version
+    attributes:
+      label: vSphere / vCenter version (same across both runs)
+      placeholder: "8.0 U2 / 9.0 / vcsim"
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Code or steps that exercise the regression. Ideally the same call site runs on both versions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: What changed
+      description: Exception, output difference, behavior change — whatever lets a maintainer see the delta.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suspected-commit
+    attributes:
+      label: Suspected commit or PR
+      description: Optional. If you've bisected or skimmed the changelog, point to the suspected change.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/yavijava/yavijava/blob/gradle/CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- 1-3 sentences. If this fixes an issue, include "Fixes #N" so the issue
+auto-closes on merge. -->
+
+## Changes
+
+<!-- Bulleted list of files/areas touched. Keep it focused on what reviewers
+need to know to read the diff. -->
+
+## Test plan
+
+- [ ] `./gradlew check` — green locally
+- [ ] Integration tests (if applicable): `./gradlew intTest`
+- [ ] If generated code in `src/main/java/com/vmware/vim25/*.java` was
+      touched: confirm `REGEN-NOTES.md` is still accurate
+
+## Notes
+
+<!-- Anything else reviewers should know: deviations from the original plan,
+follow-ups deferred, breaking changes, etc. Delete this section if empty. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,26 @@
+# Code of Conduct
+
+Participation in yavijava — issues, pull requests, discussions, and any other project space — is governed by these standards. They exist to keep collaboration productive.
+
+## Expected behavior
+
+- Keep discussion focused on the technical problem.
+- Be respectful in disagreement. Critique the work, not the person.
+- Assume good faith. Ask before you accuse.
+- Provide reproducible context (versions, stack traces, repro steps) when reporting a problem.
+
+## Unacceptable behavior
+
+- Personal attacks, insults, or threats — toward maintainers, other contributors, or third parties.
+- Harassment, including unwanted repeated contact after being asked to stop.
+- Posting private information about another person without their consent.
+- Off-topic advocacy or promotional posting that derails technical work.
+- Knowingly submitting code, issues, or PRs designed to waste maintainer time.
+
+## Enforcement
+
+Maintainers may close, edit, or hide off-topic or abusive content. Sustained or severe violations result in a project ban. Report problems to [help@yavijava.com](mailto:help@yavijava.com).
+
+## Scope
+
+This applies to all project spaces — GitHub issues, pull requests, discussions, and any communication arising from project participation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,162 @@
+# Contributing to yavijava
+
+Thanks for considering a contribution. This guide covers what you need to know to land a clean pull request.
+
+For project background, see the [README](README.md). For the rules of engagement, see the [Code of Conduct](CODE_OF_CONDUCT.md). For security issues, see [SECURITY.md](SECURITY.md) — please don't open public issues for vulnerabilities.
+
+---
+
+## Getting started
+
+### Prerequisites
+
+- **JDK 21** (Temurin or any other distribution). The project is compiled and tested against JDK 21; the CI matrix is single-version.
+- The Gradle wrapper handles Gradle itself — you don't need a system Gradle install.
+- A POSIX shell for the `./gradlew` commands. Windows users: WSL or Git Bash work; native PowerShell with `gradlew.bat` is untested but should function.
+
+### Clone and build
+
+```bash
+git clone git@github.com:yavijava/yavijava.git
+cd yavijava
+./gradlew check
+```
+
+`check` compiles, runs all unit tests, and runs SpotBugs. It should complete in well under a minute on modern hardware. If it doesn't pass on a clean checkout, that's a bug — please open an issue.
+
+---
+
+## Branch workflow
+
+**The default branch is `gradle`**, not `main` or `master`. All work goes through pull requests targeting `gradle`.
+
+Don't commit directly to `gradle`. Create a feature branch:
+
+```bash
+git checkout -b fix/short-topic-name gradle
+```
+
+Branch naming follows the same prefix convention as commit messages — `fix/...`, `feat/...`, `chore/...`, `docs/...`, `test/...`. Issue numbers in the name are optional but help; e.g. `fix/352-vtpm-bytearray-deserialization`.
+
+---
+
+## Commit conventions
+
+yavijava uses [Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and PR titles. The format is:
+
+```
+<type>(<scope>): <short imperative description>
+
+<optional longer body>
+
+<optional footers>
+```
+
+Types in active use:
+
+| Type | When |
+|---|---|
+| `fix` | Bug fix |
+| `feat` | New user-visible capability |
+| `chore` | Build, CI, deps, housekeeping |
+| `docs` | Documentation only |
+| `test` | Tests only (no production change) |
+| `refactor` | Code restructure without behavior change |
+| `perf` | Performance improvement |
+
+Scopes mirror package boundaries — most common are `ws`, `mo`, `mox`, `cf`, `util`, `gen`, `build`, `ci`, `deps`, `security`. Use the most specific scope that fits.
+
+Examples from recent history:
+
+```
+fix(ws): handle byte[][] fields in XmlGenDom deserializer (#352)
+chore(ci): bump Node 20 actions and auto-create GitHub Releases
+test(ws): add failing test for VirtualTPM byte[][] deserialization (#352)
+```
+
+If your change closes an issue, include `Fixes #N` in the PR description (not the commit message) so GitHub auto-closes the issue on merge.
+
+---
+
+## Code organization
+
+The source tree is split into two worlds. Knowing which one you're touching prevents most reviewer churn.
+
+### Generated code — do not hand-edit
+
+`src/main/java/com/vmware/vim25/` (the flat package, ~4 000 files) contains data-transfer objects, enums, and fault types produced by the `yavijava_generator` from the vSphere WSDL. `ws/VimStub.java` is also generated.
+
+**These files are overwritten on every WSDL regen.** Edits are silently lost. SpotBugs is fully suppressed for this package.
+
+If you need to change something in the generated layer, the right path is to update the generator and regenerate — see [REGEN-NOTES.md](REGEN-NOTES.md) for the procedure and the two hand-applied fixes that must be reapplied each regen.
+
+### Hand-written code — everything else
+
+| Package | Purpose |
+|---|---|
+| `com.vmware.vim25.ws` | SOAP serialization, HTTP transport, stub dispatch, pluggable `Client` interface |
+| `com.vmware.vim25.mo` | Managed object wrappers — typed Java facades over vSphere managed objects |
+| `com.vmware.vim25.mox` | Extended utilities on top of `mo/` |
+| `com.vmware.vim25.util` | Misc utilities |
+| `com.vmware.vim.cf` | Caching framework |
+| `org.doublecloud.ws.util` | Reflection and type mapping for the XML deserializer |
+
+This is where your change probably belongs.
+
+---
+
+## Tests
+
+### Unit tests
+
+`./gradlew test` runs the unit suite. Tests mix JUnit 4, JUnit 5 (via `junit-vintage-engine`), and Spock (Groovy). All run via `useJUnitPlatform()`.
+
+Most deserializer tests in `src/test/java/com/vmware/vim25/ws/` use real XML fixtures (under `src/test/resources/xml/` or `src/test/java/com/vmware/vim25/ws/xml/`) to exercise the code without a live vCenter. Follow that pattern — fixtures are easier to reason about than mocks.
+
+To run a single test class:
+
+```bash
+./gradlew test --tests "com.vmware.vim25.ws.XmlGenDomTest"
+```
+
+### Integration tests
+
+`./gradlew intTest` runs the integration suite under `src/intTest/`. These tests need a vSphere endpoint. Two paths:
+
+- **Real vCenter**: edit `src/intTest/java/VcenterInfo.properties` with your endpoint credentials.
+- **vcsim** (recommended for local dev): vcsim is a vSphere API mock from [vmware/govmomi](https://github.com/vmware/govmomi). The yavijava development environment ships a pre-built `vcsim` binary at `../esx/vcsim`; start it on `https://user:pass@127.0.0.1:8989/sdk` and point `VcenterInfo.properties` at that URL.
+
+### Release-notes tests
+
+`ReleaseNotesTest` runs as part of `./gradlew check` and asserts that `UPDATES.md` and `rel-note.txt` document specific items. When you ship a notable user-visible change, update both files and (if appropriate) add a new assertion to `ReleaseNotesTest` so the documentation stays in sync.
+
+### SpotBugs and OWASP
+
+SpotBugs runs as part of `check`. Exclusions live in `config/spotbugs/exclude.xml` and are documented inline with the reason. If SpotBugs flags real code (i.e. outside the generated package), fix the issue rather than suppressing it.
+
+OWASP Dependency-Check runs weekly in CI and on demand via `./gradlew dependencyCheckAnalyze`. It downloads a ~200 MB NVD database the first time. Suppressions live in `config/owasp/suppressions.xml`.
+
+---
+
+## Submitting a pull request
+
+1. Push your branch and open a PR against `gradle`. The PR template will prompt you for a summary, change list, and test plan.
+2. CI (`.github/workflows/ci.yml`) runs `./gradlew check` automatically on every push to the PR. Wait for it to pass.
+3. If you touched generated code, confirm `REGEN-NOTES.md` still reflects reality.
+4. If your change is user-visible, update `UPDATES.md` and `rel-note.txt`. If you can add a `ReleaseNotesTest` assertion that pins the documentation, even better.
+5. A maintainer will review. Be ready for review comments — most go through a round or two.
+
+What reviewers look for:
+
+- The change does what the PR description says, and nothing else (no surprise scope).
+- Tests that would have caught the bug exist and demonstrably fail without the fix.
+- Hand-written code paths are exercised by unit tests; integration tests are for end-to-end coverage.
+- Commit messages and PR title follow Conventional Commits.
+
+---
+
+## Releases
+
+Releases are cut by maintainers, not contributors. The short version: bump `version` in `build.gradle`, update `UPDATES.md` and `rel-note.txt` with a new section, merge, tag `vX.Y.Z`, and push the tag. `.github/workflows/publish.yml` handles signing, publishing to Maven Central, and creating the GitHub Release.
+
+If you're submitting a fix you'd like in a specific release, mention that in the PR description and we'll triage accordingly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Email [help@yavijava.com](mailto:help@yavijava.com) with the details. Please **do not** open a public GitHub issue for a suspected security problem — that puts users at risk before a fix is available.
+
+A useful report includes:
+
+- The affected yavijava version (and ideally the affected vSphere/vCenter version, if relevant).
+- A clear description of the vulnerability and its impact.
+- Steps to reproduce, or a minimal proof-of-concept.
+- Any suggested mitigation or fix you have in mind.
+
+If you'd prefer to coordinate disclosure with us, say so in the initial message and we'll work with you on a timeline.
+
+## What to expect
+
+- **Acknowledgment**: we'll confirm receipt within a few business days. The reply will come from the same address.
+- **Triage**: we'll let you know whether the report is something we can fix in yavijava, something that belongs upstream (e.g. in a transitive dependency), or out of scope.
+- **Fix and disclosure**: once a fix is ready, we'll cut a release and credit you in the release notes if you'd like. We don't commit to a fixed timeline — yavijava is maintained on a best-effort basis — but we won't sit on a confirmed report.
+
+## Supported versions
+
+Security fixes are made on a best-effort basis across actively-used major versions. The current major (see `build.gradle`) gets first attention. Older majors may receive a fix if the change is straightforward to backport and there's a credible user base still on that line.
+
+If you're running a version older than the current major and can upgrade, that's the most reliable path to a fixed build.


### PR DESCRIPTION
## Summary

Adds the full contributor-facing governance set in one PR. No source-code changes.

- `CONTRIBUTING.md` — onboarding for new contributors: clone/build, branch workflow off \`gradle\`, Conventional Commits, generated-vs-handwritten code map, test surface (unit/intTest/vcsim/ReleaseNotesTest/SpotBugs), CI gates, and a pointer to the release flow.
- `CODE_OF_CONDUCT.md` — short, behavior-focused policy. Contact: \`help@yavijava.com\`.
- `SECURITY.md` — private disclosure via email, best-effort backports across active majors, acknowledgment commitment only (no fix-time SLA).
- `.github/pull_request_template.md` — Summary / Changes / Test plan / Notes shape, mirroring what we've actually been writing on recent PRs.
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,regression,question}.yml` — YAML form templates with structured fields. Bug and regression require version info (yavijava, vSphere, JDK), reproduction, expected/actual.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; routes usage questions to Discussions and security reports to SECURITY.md.

## Changes

```
.github/ISSUE_TEMPLATE/bug_report.yml         (new)
.github/ISSUE_TEMPLATE/config.yml             (new)
.github/ISSUE_TEMPLATE/feature_request.yml    (new)
.github/ISSUE_TEMPLATE/question.yml           (new)
.github/ISSUE_TEMPLATE/regression.yml         (new)
.github/pull_request_template.md              (new)
CODE_OF_CONDUCT.md                            (new)
CONTRIBUTING.md                               (new)
SECURITY.md                                   (new)
```

## Test plan

- [x] All issue templates parse as valid YAML.
- [x] \`./gradlew check\` green — \`ReleaseNotesTest\` and the rest of the suite unaffected since no source changes.
- [ ] CI to confirm the same on the PR.

## Notes

- Discussions is already enabled on this repo (confirmed via \`gh api\`), so the config.yml \`Discussions\` contact link will render.
- All internal links use blob URLs against the \`gradle\` branch so they resolve from forks and the GitHub UI.
- The bug-report template's "Suspected cause or proposed fix" field is optional but explicitly invited — matches the style used in #352 and #353, where reporter-supplied root-cause analysis cut review time substantially.