### PR TITLE
fix(mo): guard null DynamicProperty.val in getCurrentProperty

### DIFF
--- a/src/main/java/com/vmware/vim25/mo/ManagedObject.java
+++ b/src/main/java/com/vmware/vim25/mo/ManagedObject.java
@@ -211,7 +211,7 @@ abstract public class ManagedObject {
 
             DynamicProperty[] dynaProps = objContent.getPropSet();
 
-            if ((dynaProps != null) && (dynaProps[0] != null)) {
+            if ((dynaProps != null) && (dynaProps[0] != null) && (dynaProps[0].getVal() != null)) {
                 propertyValue = PropertyCollectorUtil.convertProperty(dynaProps[0].getVal());
             }
         }

--- a/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
+++ b/src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java
@@ -37,6 +37,25 @@ public class ManagedObjectCurrentPropertyTest {
         assertNull(mo.testGetCurrentProperty("name"));
     }
 
+    // Reproduces github.com/yavijava/yavijava/issues/360 — PropertyCollector returns a
+    // DynamicProperty whose val is null (e.g. when XmlGenDom can't resolve an ArrayOf*
+    // xsi:type and leaves the field unset). getCurrentProperty should return null for
+    // a present-but-null property, matching the long-standing contract that optional
+    // managed-object properties yield null when unset.
+    @Test
+    public void getCurrentProperty_returnsNullWhenDynamicPropertyValIsNull() {
+        DynamicProperty dp = new DynamicProperty();
+        dp.setName("customValue");
+        dp.setVal(null);
+
+        ObjectContent objContent = new ObjectContent();
+        objContent.setPropSet(new DynamicProperty[]{dp});
+
+        TestManagedObject mo = new TestManagedObject(objContent);
+
+        assertNull(mo.testGetCurrentProperty("customValue"));
+    }
+
     @Test
     public void getCurrentProperty_throwsWhenMissingSetContainsFault() {
         MissingProperty missing = new MissingProperty();


### PR DESCRIPTION
## Summary

`ManagedObject.getCurrentProperty` could throw `IllegalArgumentException: Unable to convertProperty on null object.` when the `PropertyCollector` returned a `DynamicProperty` whose `val` was null. Adds a value-level null guard so the accessor returns null for unset optional properties.

Fixes #360

## Changes

- `src/main/java/com/vmware/vim25/mo/ManagedObject.java` — extend the existing guard from `dynaProps[0] != null` to also check `dynaProps[0].getVal() != null` before calling `PropertyCollectorUtil.convertProperty`.
- `src/test/java/com/vmware/vim25/mo/ManagedObjectCurrentPropertyTest.java` — regression test that injects an `ObjectContent` with a `DynamicProperty` whose `val` is null and asserts `getCurrentProperty` returns null.

## Test plan

- [x] `./gradlew check` — green locally (all tests + SpotBugs)
- [ ] Integration tests (if applicable): `./gradlew intTest`
- [ ] If generated code in `src/main/java/com/vmware/vim25/*.java` was
      touched: confirm `REGEN-NOTES.md` is still accurate — n/a, no generated code touched

## Notes

How the val=null case arises in practice: when `XmlGenDom` cannot resolve an `ArrayOf*` xsi:type for a property (the unknown-type skip path added in #320), the field is left unset, and any other code path that lands a present-but-null val on `ObjectContent.propSet` will hit the same throw. The guard here is the lower-risk fix — `PropertyCollectorUtil.convertProperty`'s `null` contract is unchanged, only the caller is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)