### PR TITLE
chore: cut 9.0.2 patch release

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -4,6 +4,14 @@ This document covers breaking changes and things to verify before upgrading your
 
 ---
 
+## 9.0.2 — Bug Fixes
+
+No breaking changes from 9.0.1. Bug fixes only:
+
+- **`ManagedObject.getCurrentProperty()` `IllegalArgumentException: Unable to convertProperty on null object.` (#360).** `getCurrentProperty` guarded `dynaProps[0] != null` but not `dynaProps[0].getVal() != null`, then passed the value straight into `PropertyCollectorUtil.convertProperty`, which throws on null input. Reachable when the `XmlGenDom` deserializer cannot resolve an `ArrayOf*` xsi:type on a `DynamicProperty.val` and leaves the field unset (see #320), or via any other code path that lands a present-but-null val on `ObjectContent.propSet`. This affected every thin accessor built on `getCurrentProperty` — for example `ManagedEntity.getCustomValue()` and `VirtualMachine.getSnapshot()`. The accessor now returns `null` for a present-but-null property, restoring the expected behavior for unset optional managed-object properties.
+
+---
+
 ## 9.0.1 — Bug Fixes
 
 No breaking changes from 9.0. Bug fixes only:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 group = "com.toastcoders"
 base.archivesName = "yavijava"
-version = '9.0.1'
+version = '9.0.2'
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 repositories {

--- a/rel-note.txt
+++ b/rel-note.txt
@@ -1,3 +1,7 @@
+What is new in Version 9.0.2?
+Bug fixes:
+- ManagedObject.getCurrentProperty() IllegalArgumentException on present-but-null DynamicProperty.val (#360)
+
 What is new in Version 9.0.1?
 Bug fixes:
 - VirtualMachine.getConfig() IllegalArgumentException on VMs with vTPM (byte[][] deserialization, #352)

--- a/src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java
+++ b/src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java
@@ -111,4 +111,24 @@ public class ReleaseNotesTest {
         assertTrue("Expected 9.0.1 entry in rel-note.txt",
             relNote().contains("9.0.1"));
     }
+
+    // --- 9.0.2 patch release ---
+
+    @Test
+    public void updatesDoc_documents902Section() throws IOException {
+        assertTrue("Expected 9.0.2 section heading in UPDATES.md",
+            updates().contains("9.0.2"));
+    }
+
+    @Test
+    public void updatesDoc_documentsGetCurrentPropertyNullValFix() throws IOException {
+        assertTrue("Expected getCurrentProperty null-val fix entry in UPDATES.md",
+            updates().contains("getCurrentProperty"));
+    }
+
+    @Test
+    public void relNote_hasVersion902Entry() throws IOException {
+        assertTrue("Expected 9.0.2 entry in rel-note.txt",
+            relNote().contains("9.0.2"));
+    }
 }


### PR DESCRIPTION
## Summary

Bug-fix-only patch release covering #360 (`ManagedObject.getCurrentProperty()` `IllegalArgumentException` on present-but-null `DynamicProperty.val`). No breaking changes from 9.0.1.

## Changes

- `build.gradle` — bump `version` 9.0.1 → 9.0.2
- `UPDATES.md` — new `## 9.0.2 — Bug Fixes` section describing the #360 fix; 9.0.1 section unchanged
- `rel-note.txt` — prepend `What is new in Version 9.0.2?` block
- `src/test/java/com/vmware/vim25/ws/ReleaseNotesTest.java` — three new assertions gating the 9.0.2 docs (section heading, `getCurrentProperty` mention, `rel-note.txt` entry)

## Test plan

- [x] `./gradlew check` — green locally (all tests + SpotBugs)
- [ ] Integration tests (if applicable): `./gradlew intTest`
- [ ] If generated code in `src/main/java/com/vmware/vim25/*.java` was
      touched: confirm `REGEN-NOTES.md` is still accurate — n/a, no generated code touched

## Notes

After merge, tagging `v9.0.2` will trigger the publish workflow (Maven publish + GitHub Release auto-create via the publish.yml updates in #357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)